### PR TITLE
Send `parent_branch` in payload rather than in query string

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -18,6 +18,7 @@ type DatabaseBranch struct {
 	ParentBranch string    `jsonapi:"attr,parent_branch" json:"parent_branch,omitempty"`
 	CreatedAt    time.Time `jsonapi:"attr,created_at,iso8601" json:"created_at"`
 	UpdatedAt    time.Time `jsonapi:"attr,updated_at,iso8601" json:"updated_at"`
+	Status       string    `jsonapi:"attr,status" json:"status,omitempty"`
 }
 
 // CreateDatabaseBranchRequest encapsulates the request for creating a new


### PR DESCRIPTION
This pull request changes things up a little bit to send the `parent_branch` via the request body, rather than within a query string. If it's missing, Go won't send it over, allowing it to resolve to the default branch.