### PR TITLE
certs: add support for the new `remote_addr` field

### DIFF
--- a/planetscale/certs.go
+++ b/planetscale/certs.go
@@ -31,6 +31,7 @@ type CertificatesService interface {
 type Cert struct {
 	ClientCert tls.Certificate
 	CACert     *x509.Certificate
+	RemoteAddr string
 }
 
 type certificatesService struct {
@@ -96,6 +97,7 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 	var cr struct {
 		Certificate      string `json:"certificate"`
 		CertificateChain string `json:"certificate_chain"`
+		RemoteAddr       string `json:"remote_addr"`
 	}
 
 	err = json.NewDecoder(res.Body).Decode(&cr)
@@ -123,6 +125,7 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 	return &Cert{
 		ClientCert: clientCert,
 		CACert:     caCert,
+		RemoteAddr: cr.RemoteAddr,
 	}, nil
 }
 

--- a/planetscale/certs_test.go
+++ b/planetscale/certs_test.go
@@ -89,15 +89,19 @@ func TestCertificates_Create(t *testing.T) {
 	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	c.Assert(err, qt.IsNil)
 
+	remoteAddr := "foo.example.com:3306"
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 
 		var out = struct {
 			Certificate      string `json:"certificate"`
 			CertificateChain string `json:"certificate_chain"`
+			RemoteAddr       string `json:"remote_addr"`
 		}{
 			Certificate:      testSignedPublicKey,
 			CertificateChain: testCACert,
+			RemoteAddr:       remoteAddr,
 		}
 
 		err := json.NewEncoder(w).Encode(out)
@@ -117,6 +121,7 @@ func TestCertificates_Create(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
+	c.Assert(cert.RemoteAddr, qt.Equals, remoteAddr)
 	c.Assert(cert.CACert, qt.Not(qt.IsNil))
 	c.Assert(cert.ClientCert, qt.Not(qt.IsNil))
 	c.Assert(cert.ClientCert.PrivateKey, qt.Not(qt.IsNil))


### PR DESCRIPTION
Compliments the new API field added here:
https://github.com/planetscale/api-bb/pull/192

/xref: https://github.com/planetscale/sql-proxy/issues/32