### PR TITLE
Unnest database create

### DIFF
--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -13,7 +13,8 @@ import (
 // CreateDatabaseRequest encapsulates the request for creating a new database.
 type CreateDatabaseRequest struct {
 	Organization string
-	Database     *Database `json:"database"`
+	Name      string    `json:"name"`
+	Notes     string    `json:"notes"`
 }
 
 // DatabaseRequest encapsulates the request for getting a single database.

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -30,10 +30,8 @@ func TestDatabases_Create(t *testing.T) {
 
 	db, err := client.Databases.Create(ctx, &CreateDatabaseRequest{
 		Organization: org,
-		Database: &Database{
-			Name:  name,
-			Notes: notes,
-		},
+		Name:         name,
+		Notes:        notes,
 	})
 
 	want := &Database{


### PR DESCRIPTION
No longer need to pass params inside of `database` on create.

https://github.com/planetscale/api-bb/pull/352