### PR TITLE
Update serialized branch credentials format

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -101,13 +101,17 @@ type databaseBranchesService struct {
 	client *Client
 }
 
-// DatabaseBranchStatus represents the status of a PlanetScale database branch.
-type DatabaseBranchStatus struct {
-	DeployPhase string `json:"deploy_phase"`
+type DatabaseBranchCredentials struct {
 	GatewayHost string `json:"mysql_gateway_host"`
 	GatewayPort int    `json:"mysql_gateway_port"`
 	User        string `json:"mysql_gateway_user"`
 	Password    string `json:"mysql_gateway_pass"`
+}
+
+// DatabaseBranchStatus represents the status of a PlanetScale database branch.
+type DatabaseBranchStatus struct {
+	Ready       bool                      `json:"ready"`
+	Credentials DatabaseBranchCredentials `json:"credentials"`
 }
 
 var _ DatabaseBranchesService = &databaseBranchesService{}

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -150,14 +150,16 @@ func TestDatabaseBranches_Status(t *testing.T) {
 		w.WriteHeader(200)
 		out := `{
     "id": "development",
-	"type": "database_branch_status",
-	"deploy_phase": "deployed",
+	"type": "BranchStatus",
+	"ready": true,
 	"created_at": "2021-01-14T10:19:23.000Z",
 	"updated_at": "2021-01-14T10:19:23.000Z",
-	"mysql_gateway_host": "test-host",
-	"mysql_gateway_port": 3306,
-	"mysql_gateway_user": "root",
-	"mysql_gateway_pass": "password"
+	"credentials": {
+		"mysql_gateway_host": "test-host",
+		"mysql_gateway_port": 3306,
+		"mysql_gateway_user": "root",
+		"mysql_gateway_pass": "password"
+	}
 }`
 
 		_, err := w.Write([]byte(out))
@@ -179,11 +181,13 @@ func TestDatabaseBranches_Status(t *testing.T) {
 	})
 
 	want := &DatabaseBranchStatus{
-		DeployPhase: "deployed",
-		GatewayHost: "test-host",
-		GatewayPort: 3306,
-		User:        "root",
-		Password:    "password",
+		Ready: true,
+		Credentials: DatabaseBranchCredentials{
+			GatewayHost: "test-host",
+			GatewayPort: 3306,
+			User:        "root",
+			Password:    "password",
+		},
 	}
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
Credentials are [now served][1] under a `credentials` key. Also replaces the unused `deploy_phase` key with `ready`.

[1]: https://github.com/planetscale/api-bb/pull/723