### PR TITLE
client: don't include error if status code is 500

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -199,7 +199,6 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 				Code: ErrInternal,
 				Meta: map[string]string{
 					"body": string(out),
-					"err":  err.Error(),
 				},
 			}
 		}

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -40,6 +40,16 @@ func TestDo(t *testing.T) {
 			},
 		},
 		{
+			desc:       "returns ErrorResponse for 5xx errors",
+			statusCode: http.StatusInternalServerError,
+			method:     http.MethodGet,
+			response:   `{}`,
+			expectedError: &Error{
+				msg:  "internal error, please open an issue to github.com/planetscale/planetscale-go",
+				Code: ErrInternal,
+			},
+		},
+		{
 			desc:       "returns an HTTP response 200 when posting a request",
 			statusCode: http.StatusOK,
 			response: `


### PR DESCRIPTION
This PR fixes a nil pointer dereference panic if the response is 500 and has an invalid response body. Because the `json.Unmarshal()` command doesn't return an error, we shouldn't try to include a nil error in the error response body.

closes: https://github.com/planetscale/project-big-bang/issues/208
