### PR TITLE
Add helper function to dial to a PlanetScale database

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,50 @@ client, _ := planetscale.NewClient(
 	planetscale.WithAccessToken(token),
 )
 ```
+
+## Connecting to a PlanetScale Database
+
+The `planetscale-go` packge provides a helper method to simplify connecting to a PlanetScale database. Here is an example you can use (_Please make sure to handle errors in your production application._):
+
+
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/planetscale/planetscale-go/planetscale/dbutil"
+)
+
+func main() {
+	token := os.Getenv("PLANETSCALE_TOKEN")
+	ctx := context.Background()
+
+	// create a new PlanetScale API client with the given access token
+	client, _ := planetscale.NewClient(
+		planetscale.WithAccessToken(token),
+	)
+
+	// create the Dial config
+	dialCfg := &DialConfig{
+		Organization: "my-org",
+		Database:     "my-awesome-database",
+		Branch:       "my-branch",
+		Client:       client,
+	}
+
+	// dbutil.Dial returns a ready to use *sql.DB instance.
+	db, _ := dbutil.Dial(ctx, dialCfg)
+
+	// make a query
+	var version string
+	_ = db.QueryRow("SELECT VERSION()").Scan(&version)
+
+	// prints 'MySQL version: 8.0.23'
+	fmt.Println("MySQL version:", version)
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/frankban/quicktest v1.13.0
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -1,0 +1,127 @@
+package dbutil
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-sql-driver/mysql"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+// DialConfig defines the configuration to use to dial to a PlanetScale Database
+type DialConfig struct {
+	// Organization represents a PlanetScale organization.
+	Organization string
+
+	// Database defines the PlanetScale database to connect.
+	Database string
+
+	// Branch defines the PlanetScale branch to connect.
+	Branch string
+
+	// Client defines a PlanetScale client. Use planetscale.NewClient() to
+	// create a new instance.
+	Client *ps.Client
+}
+
+// Dial creates a secure connection to a PlanetScale database with the given
+// configuration.
+func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
+	if cfg.Client == nil {
+		return nil, errors.New("planetscale Client is not set")
+	}
+
+	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate private key: %s", err)
+	}
+
+	remoteAddr, tlsConfig, err := createTLSConfig(ctx, cfg, pkey, cfg.Client.Certificates)
+	if err != nil {
+		return nil, err
+	}
+
+	key := "planetscale"
+	err = mysql.RegisterTLSConfig(key, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	mysqlCfg := mysql.NewConfig()
+	mysqlCfg.Addr = remoteAddr
+	mysqlCfg.Net = "tcp"
+	mysqlCfg.TLSConfig = key
+
+	fmt.Println("==> connecting to the db ...")
+	db, err := sql.Open("mysql", mysqlCfg.FormatDSN())
+	if err == nil {
+		err = db.PingContext(ctx)
+	}
+
+	return db, err
+}
+
+// createTLSConfig is an internal function that returns the remote address and
+// tls.Config to be used to connect to a PlanetScale database.
+func createTLSConfig(
+	ctx context.Context,
+	cfg *DialConfig,
+	pkey *rsa.PrivateKey,
+	certService ps.CertificatesService,
+) (string, *tls.Config, error) {
+	if cfg.Organization == "" {
+		return "", nil, errors.New("organization is not set")
+	}
+
+	if cfg.Database == "" {
+		return "", nil, errors.New("database is not set")
+	}
+
+	if cfg.Branch == "" {
+		return "", nil, errors.New("branch is not set")
+	}
+
+	cert, err := certService.Create(ctx, &ps.CreateCertificateRequest{
+		Organization: cfg.Organization,
+		DatabaseName: cfg.Database,
+		Branch:       cfg.Branch,
+		PrivateKey:   pkey,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	rootCertPool := x509.NewCertPool()
+	rootCertPool.AddCert(cert.CACert)
+
+	serverName := fmt.Sprintf("%s.%s.%s.%s", cfg.Branch, cfg.Database, cfg.Organization, cert.RemoteAddr)
+	remoteAddr := net.JoinHostPort(serverName, strconv.Itoa(cert.Ports.MySQL))
+
+	return remoteAddr, &tls.Config{
+		RootCAs:      rootCertPool,
+		Certificates: []tls.Certificate{cert.ClientCert},
+		ServerName:   serverName,
+		// We need to set InsecureSkipVerify to true due to
+		// https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/194
+		// https://tip.golang.org/doc/go1.11#crypto/x509
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			opts := x509.VerifyOptions{
+				Roots:         rootCertPool,
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := cs.PeerCertificates[0].Verify(opts)
+			return err
+		},
+	}, nil
+}

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -59,7 +59,6 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 	mysqlCfg.Net = "tcp"
 	mysqlCfg.TLSConfig = key
 
-	fmt.Println("==> connecting to the db ...")
 	db, err := sql.Open("mysql", mysqlCfg.FormatDSN())
 	if err == nil {
 		err = db.PingContext(ctx)

--- a/planetscale/dbutil/dbutil_test.go
+++ b/planetscale/dbutil/dbutil_test.go
@@ -1,0 +1,174 @@
+package dbutil
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/planetscale-go/planetscale"
+)
+
+var (
+	testPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAoTevM6Gx0+TD5/co/ddfIsBTKiCmjE1CKARqb8QNGEGYu61V
+k74HnZ6+i9FKVFKyYBsvETJM2XugGkHmAY85r2R5HWou9zcmLkM6X71As70ktQOH
+NUXqRmbRSlsKbFnWw5MF7I5pSyh2WGGaLeheJDX9qTv092G+NCgupHKHyI4HK0wG
+RtpLJtYHjdpoEM53Mh3d5JDA13BUJaWCc4DPR5wOdLahthTegsNWQql9csToy7nJ
+5JhGY3NAHY3bKcRKkIg0gueYIw/AovTTJV+Zf+CIUoMUt5VvvnlRsk24gUWDuVQ1
+qUKdEsyac4juKfatd9HihjXOzg2tJ/2n9/qTuQIDAQABAoIBAGd6R2E7itl3v2rX
+UJ9FqtGyYm7q0BvDxw/KbcrZKpKEIBVuVzxiP58i8ijqJ+xhvA5FxHskLwF1ATl5
+TLl5hcwXEEoaCpUw97e//OrQnYQAhlwNLK679nhDrFgugU00iM21Q5sneVv9V6C4
+3O5UdICHiw4h5sUWHrB5jh6NSKwnwEjS4qswwIZhKdKNjpuLhP4lQ4E4WXiBs7eg
+OEeuoVA6L6uDwmoJ9P1bLn3F5f9UAAQ4s91aCXmnUJeCxec/zJuGK0CRKznLJ3G4
+LmuNS3NYdmW/PN4wX0J0p4cr1LxD2WQfFuOIII13t7Y/BEMxtxDYpXqAlWEczKjd
+ckQw4iUCgYEA1Rk3+3IUdOUVASorgtU2+PODBI5KEybTMFN3tlfCYZC/fwZxK0Hx
+rGSUduXtEeaR21DDSZ3ndG1cCHATsQVpWeuzfuC14j6/rhflru9ikqCMSfp5er6l
+QGXqvLLUBvK7WsPqf1Tm/9tox7Ctei+5rs3nwtWAzqALBNQH+aafY9sCgYEAwayY
+oY1Vu1amBVzUB7bjw3E+UPNrPnRECstL1NYGd2jt+oAZpS6LO5E46LEspN5dNQAS
+2rknRP9RbUbJ+LZ9X9w5su7d6odAkHc1oJgw3zaZqoGCLRH2Ls4qe4kzjIrRVGSw
+cQnnYvpACZ50Gb3kM3qo78UFaELiNyVcJBfAxPsCgYByvQRmj9Mx6ZK4sNMCu/jA
+bKUz08VQsIvvrlF7zZ7s13o0U+ylRPlyQCmsJzrRc5s/QioUPkA8cRGnvWjs3KQP
+9ZgNDcMBEZY1j8psuZoSpv1Ca+nyzCnAFeAhQAxnvVRhl7FwY++I/cNaGegeLQpG
+c7mBL2IOXx/vtpagtjWGFwKBgE53Vv9c+7cCzBCwI1dcybqNTuoNNQ4AnPCinP6G
+F+iZIpGzBLDfwplHpP7hiWziinDGrtze1wIlTyAu5fVWOkV0PAw6qr4yPf5Jzfha
+sLI+tNNX1R3dgRhFfwC9/ZybQWQnxzSFBrIbIYbEI9WqEaKpt3gtIpuzPWOKR2J4
+HSmxAoGBAKPUEj4XcMz7aj+Vj0M0CjEIdlbi8vTRGDLRZIU+NMef318BDUxuyhPH
+UDbbLFgm1/tckL9xKi4es6n17LH2LoXCi13/pvXscQHFZifCHH8ml7QO2X31R4UG
+2guX2Rmbpb/mX9kyIeLGS94BfK0YwRYjKaNVWM3E1aOp19++oLu4
+-----END RSA PRIVATE KEY-----`
+
+	testSignedPublicKey = `-----BEGIN CERTIFICATE-----
+MIICuzCCAaMCFHLnUdZL1i+gyDYACOCVlf/kuKJ7MA0GCSqGSIb3DQEBCwUAMBAx
+DjAMBgNVBAMMBW15LWNhMB4XDTIxMDExNDE0MjU0MFoXDTIyMDExNDE0MjU0MFow
+JDEiMCAGA1UEAwwZb3JnLWZvby9kYi1mb28vYnJhbmNoLWZvbzCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBAKE3rzOhsdPkw+f3KP3XXyLAUyogpoxNQigE
+am/EDRhBmLutVZO+B52evovRSlRSsmAbLxEyTNl7oBpB5gGPOa9keR1qLvc3Ji5D
+Ol+9QLO9JLUDhzVF6kZm0UpbCmxZ1sOTBeyOaUsodlhhmi3oXiQ1/ak79PdhvjQo
+LqRyh8iOBytMBkbaSybWB43aaBDOdzId3eSQwNdwVCWlgnOAz0ecDnS2obYU3oLD
+VkKpfXLE6Mu5yeSYRmNzQB2N2ynESpCINILnmCMPwKL00yVfmX/giFKDFLeVb755
+UbJNuIFFg7lUNalCnRLMmnOI7in2rXfR4oY1zs4NrSf9p/f6k7kCAwEAATANBgkq
+hkiG9w0BAQsFAAOCAQEAzYwmGPb0qaQtK07I+4u1G0+DlwK+aWc/D3oLC/rF9XPq
+mlh48nTacsJJF12VtlkQI+t6Mjw8F1CYQjeWlUMq5aItZKXGgiNRvT1LmqMNwSWA
+J4hqgsGoBlP8WKRls6W7AmiK8cvd3sxAwFble4QGtmRb1QLTBoYdt5Fxd97+M57t
+iveAOhvMQCp7sNbUQCYvugzFIc5ScGDQTho0sCXXPahhuhHjy3tG1JG1fwYRyV+H
+MMSi245zV4dLChwoDpEkwODUHiR2TEv+q+T4fyP+zHISOKMdW15nIGjBuNByTzII
+jncAhUUJgqpbMBTA3oHy1gZs/6wTCOWyz7E0LtlxCw==
+-----END CERTIFICATE-----`
+
+	testCACert = `-----BEGIN CERTIFICATE-----
+MIIDATCCAemgAwIBAgIUGrBsGrF/ecgMfMzNB8/ARHPFkRswDQYJKoZIhvcNAQEL
+BQAwEDEOMAwGA1UEAwwFbXktY2EwHhcNMjEwMTE0MTQyMDIwWhcNMjIwMTE0MTQy
+MDIwWjAQMQ4wDAYDVQQDDAVteS1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBANPN0hhlHco+BEM0Yd3U3Pa3ZC+M0wMCA5HrKcTaxCw5xGs05W/+Ti0P
+EPg6a5yymx41Z1KdPWsRqvjDZtZgdjwt0wSIFoLNvssrbXHRLxe5tv7PBLLMrHdN
+bzKAibsganF4ZUC4PhjVmk9rE94NGvUQZRL5nK//fgktlaQHUWEhihWb/XAS62F6
+/tiHyOLg/mUNAB6M64B5iSrHyYsqtH5oZXXSIeBUYtgtuSRF2uyhgLuoVwYA8NUC
+fBn+sruZhD1sAFbTCuObU9zoA7UAQCdtmNpLQUZWxzR05qjVT9ydMIncG/RBOPaH
+hT/1TJnrpEb7dhgaE8WHm9NOV/Gqp5cCAwEAAaNTMFEwHQYDVR0OBBYEFIsGnUu1
+J/jeGbUK2rgbJZwjoygmMB8GA1UdIwQYMBaAFIsGnUu1J/jeGbUK2rgbJZwjoygm
+MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAMy+H4kauCd/1n31
+WnFS1k07ZupxUQrZJNYU83ofWQOff9ni2e6klzWjvm8v443iz20naACLNGK5oD8j
+x3J+xdrRvEMgmChLVXDUh2e6HmCVhvytM3VXVqoXOzMXjv3UH6zzTO8DFLoF4D/f
+Ym0qkgv2pOoyUe+ortHb+j2JMWma+GJgs3X7RpHduqqb8zxFIBfW3I/KbFfpOStC
+1inUrRrfg1GP794QvZFFkW3/AlYddu1+oxmU0NtTzbglJG0dWhEKd6CRImVeWzWe
+ZOmBO8+XvKtmXamaYmI9/+wexP5nXGccfeku0QWF/5/5+YrZwAmugQqY9Lp7B97+
+CObkNf8=
+-----END CERTIFICATE-----`
+)
+
+func TestCreateTLSConfig(t *testing.T) {
+	ctx := context.Background()
+	c := qt.New(t)
+
+	block, _ := pem.Decode([]byte(testPrivateKey))
+	c.Assert(block, qt.Not(qt.IsNil), qt.Commentf("invalid PEM: "+testPrivateKey))
+	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	c.Assert(err, qt.IsNil)
+
+	privateKey := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(pkey),
+		},
+	)
+
+	clientCert, err := tls.X509KeyPair([]byte(testSignedPublicKey), privateKey)
+	c.Assert(err, qt.IsNil)
+
+	caCert, err := parseCert(testCACert)
+	c.Assert(err, qt.IsNil)
+
+	org := "planetscale"
+	database := "mydb"
+	branch := "mydb"
+	remoteAddr := "foo.example.com"
+	port := 3306
+
+	certService := &fakeCertService{
+		createFn: func(ctx context.Context, req *planetscale.CreateCertificateRequest) (*planetscale.Cert, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.DatabaseName, qt.Equals, database)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.PrivateKey, qt.Equals, pkey)
+
+			return &planetscale.Cert{
+				ClientCert: clientCert,
+				CACert:     caCert,
+				RemoteAddr: remoteAddr,
+				Ports: planetscale.RemotePorts{
+					MySQL: port,
+				},
+			}, nil
+		},
+	}
+
+	dialCfg := &DialConfig{
+		Organization: org,
+		Database:     database,
+		Branch:       branch,
+	}
+
+	dbAddr, tlsConfig, err := createTLSConfig(ctx, dialCfg, pkey, certService)
+	c.Assert(err, qt.IsNil)
+	c.Assert(certService.createFnInvoked, qt.IsTrue)
+
+	c.Assert(dbAddr, qt.Equals, net.JoinHostPort(tlsConfig.ServerName, strconv.Itoa(port)))
+
+	c.Assert(tlsConfig.RootCAs, qt.Not(qt.IsNil))
+	c.Assert(tlsConfig.InsecureSkipVerify, qt.IsTrue)
+	c.Assert(tlsConfig.Certificates, qt.HasLen, 1)
+
+	serverName := fmt.Sprintf("%s.%s.%s.%s", branch, database, org, remoteAddr)
+	c.Assert(tlsConfig.ServerName, qt.Equals, serverName)
+
+	ccert := tlsConfig.Certificates[0]
+
+	ct, err := x509.ParseCertificate(ccert.Certificate[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(ct.Subject.CommonName, qt.Equals, "org-foo/db-foo/branch-foo")
+}
+
+type fakeCertService struct {
+	createFn        func(context.Context, *planetscale.CreateCertificateRequest) (*planetscale.Cert, error)
+	createFnInvoked bool
+}
+
+func (f *fakeCertService) Create(ctx context.Context, req *planetscale.CreateCertificateRequest) (*planetscale.Cert, error) {
+	f.createFnInvoked = true
+	return f.createFn(ctx, req)
+}
+
+func parseCert(pemCert string) (*x509.Certificate, error) {
+	bl, _ := pem.Decode([]byte(pemCert))
+	if bl == nil {
+		return nil, errors.New("invalid PEM: " + pemCert)
+	}
+	return x509.ParseCertificate(bl.Bytes)
+}


### PR DESCRIPTION
This PR introduces a new `planetscale/dbutil` package to simplify
creating connections from a Go service to a PlanetScale database.

Here is an example how it can be imported and used

```go
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/planetscale/planetscale-go/planetscale"
	"github.com/planetscale/planetscale-go/planetscale/dbutil"
)

func main() {
	token := os.Getenv("PLANETSCALE_TOKEN")
	ctx := context.Background()

	// create a new PlanetScale API client with the given access token
	client, _ := planetscale.NewClient(
		planetscale.WithAccessToken(token),
	)

	// dbutil.Dial returns a ready to use *sql.DB instance.
	db, err := dbutil.Dial(ctx, &dbutil.DialConfig{
		Organization: "my-org",
		Database:     "my-awesome-database",
		Branch:       "my-branch",
		Client:       client,
	})
	if err != nil {
		return err
	}

	// make a query
	var version string
	_ = db.QueryRow("SELECT VERSION()").Scan(&version)

	// prints 'MySQL version: 8.0.23'
	fmt.Println("MySQL version:", version)
}
```

I'm not sure about the `dbutil` package naming yet, so that might change.

/xref https://github.com/planetscale/beta/discussions/24
