### PR TITLE
Allow users to pass a *mysql.Config to dbutil.Dial

### DIFF
--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -30,6 +30,12 @@ type DialConfig struct {
 	// Client defines a PlanetScale client. Use planetscale.NewClient() to
 	// create a new instance.
 	Client *ps.Client
+
+	// MySQLConfig is optional and can be used to pass MySQL driver
+	// specific options. Note that some configuration fields
+	// will always be overwritten in order to properly connect
+	// to PlanetScale.
+	MySQLConfig *mysql.Config
 }
 
 // Dial creates a secure connection to a PlanetScale database with the given
@@ -54,7 +60,11 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	mysqlCfg := mysql.NewConfig()
+
+	mysqlCfg := cfg.MySQLConfig
+	if mysqlCfg == nil {
+		mysqlCfg = mysql.NewConfig()
+	}
 	mysqlCfg.Addr = remoteAddr
 	mysqlCfg.Net = "tcp"
 	mysqlCfg.TLSConfig = key

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -61,7 +61,7 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 		return nil, err
 	}
 
-	mysqlCfg := cfg.MySQLConfig
+	mysqlCfg := *cfg.MySQLConfig
 	if mysqlCfg == nil {
 		mysqlCfg = mysql.NewConfig()
 	}

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -61,9 +61,10 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 		return nil, err
 	}
 
-	mysqlCfg := *cfg.MySQLConfig
-	if mysqlCfg == nil {
-		mysqlCfg = mysql.NewConfig()
+	mysqlCfg := mysql.NewConfig()
+	if mysqlCfg != nil {
+		// shallow-copy to avoid modifying user data
+		*mysqlCfg = *cfg.MySQLConfig
 	}
 	mysqlCfg.Addr = remoteAddr
 	mysqlCfg.Net = "tcp"


### PR DESCRIPTION
👋🏼 

Giving the new `dbutil` a try, I realized I was unable to pass custom driver configurations such as `ParseTime = true` or any other ones described here: https://github.com/go-sql-driver/mysql#parameters

This PR makes it so that a user can pass an optional *mysql.Config to set such parameters. 

This change is backwards compatible, thanks to the dial config struct. 

Thinking a little bit further, I realize that this package forces the users to always use this particular MySQL driver. I wonder if we should allow users to use alternative drivers by defining an interface instead of hardcoding the dependency. But I'm happy to use this driver personally. 

Thanks!