### PR TITLE
client: include http status code with the error

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -174,11 +174,12 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 		if err != nil {
 			if _, ok := err.(*json.SyntaxError); ok {
 				return &Error{
-					msg:  "malformed response body received",
+					msg:  "malformed error response body received",
 					Code: ErrResponseMalformed,
 					Meta: map[string]string{
-						"body": string(out),
-						"err":  err.Error(),
+						"body":        string(out),
+						"err":         err.Error(),
+						"http_status": http.StatusText(res.StatusCode),
 					},
 				}
 			}
@@ -193,10 +194,11 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 		// TODO(fatih): fix the behavior on the API side
 		if *errorRes == (errorResponse{}) {
 			return &Error{
-				msg:  "internal error, please open an issue to github.com/planetscale/planetscale-go",
+				msg:  "internal error, response body doesn't match error type signature",
 				Code: ErrInternal,
 				Meta: map[string]string{
-					"body": string(out),
+					"body":        string(out),
+					"http_status": http.StatusText(res.StatusCode),
 				},
 			}
 		}
@@ -231,7 +233,8 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 				msg:  "malformed response body received",
 				Code: ErrResponseMalformed,
 				Meta: map[string]string{
-					"body": string(out),
+					"body":        string(out),
+					"http_status": http.StatusText(res.StatusCode),
 				},
 			}
 		}

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -45,7 +45,7 @@ func TestDo(t *testing.T) {
 			method:     http.MethodGet,
 			response:   `{}`,
 			expectedError: &Error{
-				msg:  "internal error, please open an issue to github.com/planetscale/planetscale-go",
+				msg:  "internal error, response body doesn't match error type signature",
 				Code: ErrInternal,
 			},
 		},

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -140,7 +140,7 @@ func TestDatabases_List_malformed_response(t *testing.T) {
 	})
 
 	c.Assert(err, qt.Not(qt.IsNil))
-	c.Assert(err, qt.ErrorMatches, `malformed response body received`)
+	c.Assert(err, qt.ErrorMatches, `malformed error response body received`)
 }
 
 func TestDatabases_Empty(t *testing.T) {


### PR DESCRIPTION
This PR includes now the HTTP status code as part of the returned error.
Users of this client can type assert the error value to get more
information about the underlying error.

We also remove the error to open an issue to planetscale-go repository
as that is not very helpful for both the user and for us.