### PR TITLE
Set mysql config parse time to true

### DIFF
--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -58,6 +58,7 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 	mysqlCfg.Addr = remoteAddr
 	mysqlCfg.Net = "tcp"
 	mysqlCfg.TLSConfig = key
+	mysqlCfg.ParseTime = true
 
 	db, err := sql.Open("mysql", mysqlCfg.FormatDSN())
 	if err == nil {


### PR DESCRIPTION
## Description

This pull request fixes an issue encountered when trying to unmarshal MySQL time fields into golang's `*time.Time`. For the following MySQL table:

```sql
CREATE TABLE `my_table` (
      `added` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
) ENGINE=InnoDB;
```

We can use the following Go struct to `select` from it:

```go
type MyTable struct {
    Added *time.Time
}
```

To enable the parsing of timestamps/dates into `*time.Time` go type, one would use the `database/sql` package to connect to the database like so:

```go
sql.Open("mysql", MySQLConnectionString + "?parseTime=true")
```

Without `parsingTime=true`, the following error will be prompted:

```
 sql: Scan error on column index 3, name "added": unsupported Scan, storing driver.Value type []uint8 into type *time.Time
```

The `dbutil` does not allow personalized configuration of the MySQL connection string, to temporarily fix the time parsing issue with `*time.Time` type, this pull request set the `ParseTime` attribute of MySQL configuration to `true`.
