### PR TITLE
Add regions to database and branch creation

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -28,6 +28,7 @@ type databaseBranchesResponse struct {
 type CreateDatabaseBranchRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
+	Region       string `json:"region,omitempty"`
 	Branch       *DatabaseBranch
 }
 

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -14,6 +14,7 @@ type DatabaseBranch struct {
 	Name         string    `json:"name"`
 	Notes        string    `json:"notes"`
 	ParentBranch string    `json:"parent_branch"`
+	Region       Region    `json:"region"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	Status       string    `json:"status,omitempty"`

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -17,7 +17,7 @@ func TestDatabaseBranches_Create(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": {"slug": "us-west", "display_name": "US West"}}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -33,6 +33,7 @@ func TestDatabaseBranches_Create(t *testing.T) {
 	db, err := client.DatabaseBranches.Create(ctx, &CreateDatabaseBranchRequest{
 		Organization: org,
 		Database:     name,
+		Region:       "us-west",
 		Branch: &DatabaseBranch{
 			Name:  testBranch,
 			Notes: notes,
@@ -40,8 +41,12 @@ func TestDatabaseBranches_Create(t *testing.T) {
 	})
 
 	want := &DatabaseBranch{
-		Name:      testBranch,
-		Notes:     notes,
+		Name:  testBranch,
+		Notes: notes,
+		Region: Region{
+			Slug: "us-west",
+			Name: "US West",
+		},
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 	}

--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -14,6 +14,7 @@ type CreateDatabaseRequest struct {
 	Organization string
 	Name         string `json:"name"`
 	Notes        string `json:"notes"`
+	Region       string `json:"region,omitempty"`
 }
 
 // DatabaseRequest encapsulates the request for getting a single database.

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -20,7 +20,7 @@ func TestDatabases_Create(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": { "slug": "us-west", "display_name": "US West" }}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -35,13 +35,18 @@ func TestDatabases_Create(t *testing.T) {
 
 	db, err := client.Databases.Create(ctx, &CreateDatabaseRequest{
 		Organization: org,
+		Region:       "us-west",
 		Name:         name,
 		Notes:        notes,
 	})
 
 	want := &Database{
-		Name:      name,
-		Notes:     notes,
+		Name:  name,
+		Notes: notes,
+		Region: Region{
+			Slug: "us-west",
+			Name: "US West",
+		},
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 	}

--- a/planetscale/regions.go
+++ b/planetscale/regions.go
@@ -10,8 +10,9 @@ import (
 const regionsAPIPath = "v1/regions"
 
 type Region struct {
-	Slug string `json:"slug"`
-	Name string `json:"display_name"`
+	Slug    string `json:"slug"`
+	Name    string `json:"display_name"`
+	Enabled bool   `json:"enabled"`
 }
 
 type regionsResponse struct {

--- a/planetscale/regions_test.go
+++ b/planetscale/regions_test.go
@@ -20,7 +20,8 @@ func TestRegions_List(t *testing.T) {
 			"id": "my-cool-org",
 			"type": "Region",
 			"slug": "us-east",
-			"display_name": "US East"
+			"display_name": "US East",
+			"enabled": true
 		}
 	]
 }`
@@ -39,8 +40,9 @@ func TestRegions_List(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	want := []*Region{
 		{
-			Name: "US East",
-			Slug: "us-east",
+			Name:    "US East",
+			Slug:    "us-east",
+			Enabled: true,
 		},
 	}
 


### PR DESCRIPTION
This pull request adds the `region` attribute to our database and branch create request objects. 