### PR TITLE
Flatten request object for creating a database branch

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -28,7 +28,9 @@ type databaseBranchesResponse struct {
 type CreateDatabaseBranchRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
-	Branch       *DatabaseBranch
+	Name         string `json:"name"`
+	Notes        string `json:"notes"`
+	ParentBranch string `json:"parent_branch"`
 }
 
 // ListDatabaseBranchesRequest encapsulates the request for listing the branches
@@ -161,7 +163,7 @@ func (d *databaseBranchesService) Schema(ctx context.Context, schemaReq *BranchS
 func (d *databaseBranchesService) Create(ctx context.Context, createReq *CreateDatabaseBranchRequest) (*DatabaseBranch, error) {
 	path := databaseBranchesAPIPath(createReq.Organization, createReq.Database)
 
-	req, err := d.client.newRequest(http.MethodPost, path, createReq.Branch)
+	req, err := d.client.newRequest(http.MethodPost, path, createReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating request for branch database")
 	}

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -33,10 +33,8 @@ func TestDatabaseBranches_Create(t *testing.T) {
 	db, err := client.DatabaseBranches.Create(ctx, &CreateDatabaseBranchRequest{
 		Organization: org,
 		Database:     name,
-		Branch: &DatabaseBranch{
-			Name:  testBranch,
-			Notes: notes,
-		},
+		Name:         testBranch,
+		Notes:        notes,
 	})
 
 	want := &DatabaseBranch{


### PR DESCRIPTION
This pull request changes the `CreateDatabaseBranchRequest` struct to not rely on a `Branch` struct, rather, we can just directly define the attributes for branching directly within the struct.