### PR TITLE
Remove notes from branch creation.

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -12,7 +12,6 @@ import (
 // DatabaseBranch represents a database branch.
 type DatabaseBranch struct {
 	Name         string    `json:"name"`
-	Notes        string    `json:"notes"`
 	ParentBranch string    `json:"parent_branch"`
 	Region       Region    `json:"region"`
 	CreatedAt    time.Time `json:"created_at"`
@@ -31,7 +30,6 @@ type CreateDatabaseBranchRequest struct {
 	Database     string `json:"-"`
 	Region       string `json:"region,omitempty"`
 	Name         string `json:"name"`
-	Notes        string `json:"notes"`
 	ParentBranch string `json:"parent_branch"`
 }
 

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -17,7 +17,7 @@ func TestDatabaseBranches_Create(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": {"slug": "us-west", "display_name": "US West"}}`
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": {"slug": "us-west", "display_name": "US West"}}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -28,19 +28,16 @@ func TestDatabaseBranches_Create(t *testing.T) {
 	ctx := context.Background()
 	org := "my-org"
 	name := "planetscale-go-test-db"
-	notes := "This is a test DB created from the planetscale-go API library"
 
 	db, err := client.DatabaseBranches.Create(ctx, &CreateDatabaseBranchRequest{
 		Organization: org,
 		Database:     name,
 		Region:       "us-west",
 		Name:         testBranch,
-		Notes:        notes,
 	})
 
 	want := &DatabaseBranch{
-		Name:  testBranch,
-		Notes: notes,
+		Name: testBranch,
 		Region: Region{
 			Slug: "us-west",
 			Name: "US West",
@@ -58,7 +55,7 @@ func TestDatabaseBranches_List(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"data":[{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
+		out := `{"data":[{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -69,7 +66,6 @@ func TestDatabaseBranches_List(t *testing.T) {
 	ctx := context.Background()
 	org := "my-org"
 	name := "planetscale-go-test-db"
-	notes := "This is a test DB created from the planetscale-go API library"
 
 	db, err := client.DatabaseBranches.List(ctx, &ListDatabaseBranchesRequest{
 		Organization: org,
@@ -78,7 +74,6 @@ func TestDatabaseBranches_List(t *testing.T) {
 
 	want := []*DatabaseBranch{{
 		Name:      testBranch,
-		Notes:     notes,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 	}}
@@ -118,7 +113,7 @@ func TestDatabaseBranches_Get(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -129,7 +124,6 @@ func TestDatabaseBranches_Get(t *testing.T) {
 	ctx := context.Background()
 	org := "my-org"
 	name := "planetscale-go-test-db"
-	notes := "This is a test DB created from the planetscale-go API library"
 
 	db, err := client.DatabaseBranches.Get(ctx, &GetDatabaseBranchRequest{
 		Organization: org,
@@ -137,7 +131,6 @@ func TestDatabaseBranches_Get(t *testing.T) {
 
 	want := &DatabaseBranch{
 		Name:      testBranch,
-		Notes:     notes,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 	}


### PR DESCRIPTION
This pull request stops sending notes over with branch creation, because we don't really use it anywhere.