### PR TITLE
Update logic to be agnostic for the private key type

### DIFF
--- a/planetscale/certs.go
+++ b/planetscale/certs.go
@@ -59,11 +59,11 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 		CommonName: cn,
 	}
 
-	switch r.PrivateKey.(type) {
+	switch priv := r.PrivateKey.(type) {
 	case *rsa.PrivateKey:
 	case *ecdsa.PrivateKey:
 	default:
-		return nil, fmt.Errorf("unsupported key type: %T, only supports ECDSA and RSA private keys", r.PrivateKey)
+		return nil, fmt.Errorf("unsupported key type: %T, only supports ECDSA and RSA private keys", priv)
 	}
 
 	template := x509.CertificateRequest{

--- a/planetscale/certs.go
+++ b/planetscale/certs.go
@@ -59,20 +59,16 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 		CommonName: cn,
 	}
 
-	var signatureAlgorithm x509.SignatureAlgorithm
 	switch r.PrivateKey.(type) {
 	case *rsa.PrivateKey:
-		signatureAlgorithm = x509.SHA256WithRSA
 	case *ecdsa.PrivateKey:
-		signatureAlgorithm = x509.ECDSAWithSHA256
 	default:
-		return nil, fmt.Errorf("unsupported key type, only supports ECDSA & RSA private keys")
+		return nil, fmt.Errorf("unsupported key type: %T, only supports ECDSA and RSA private keys", r.PrivateKey)
 	}
 
 	template := x509.CertificateRequest{
-		Version:            1,
-		Subject:            subj,
-		SignatureAlgorithm: signatureAlgorithm,
+		Version: 1,
+		Subject: subj,
 	}
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, r.PrivateKey)

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -2,6 +2,7 @@ package dbutil
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -38,6 +39,14 @@ type DialConfig struct {
 	MySQLConfig *mysql.Config
 }
 
+func generateKey() (crypto.PrivateKey, error) {
+	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	return &pkey, nil
+}
+
 // Dial creates a secure connection to a PlanetScale database with the given
 // configuration.
 func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
@@ -45,7 +54,7 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 		return nil, errors.New("planetscale Client is not set")
 	}
 
-	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	pkey, err := generateKey()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate private key: %s", err)
 	}
@@ -84,7 +93,7 @@ func Dial(ctx context.Context, cfg *DialConfig) (*sql.DB, error) {
 func createTLSConfig(
 	ctx context.Context,
 	cfg *DialConfig,
-	pkey *rsa.PrivateKey,
+	pkey crypto.PrivateKey,
 	certService ps.CertificatesService,
 ) (string, *tls.Config, error) {
 	if cfg.Organization == "" {


### PR DESCRIPTION
Go has the crypto.PrivateKey interface to represent a type agnostic private key.

The code here is updated to remove the *rsa.PrivateKey assumption and instead to be agnostic for the specific type of key. In the few places we need to detect the type, we can do so appropriately (mostly in serialization logic).