### PR TITLE
Switch to generating ECDSA keys by default

### DIFF
--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -3,8 +3,9 @@ package dbutil
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -40,7 +41,7 @@ type DialConfig struct {
 }
 
 func generateKey() (crypto.PrivateKey, error) {
-	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	pkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/planetscale/integration_test.go
+++ b/planetscale/integration_test.go
@@ -4,8 +4,9 @@ package planetscale
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"fmt"
 	"os"
 	"testing"
@@ -35,7 +36,7 @@ func TestIntegration_Certificate_Create(t *testing.T) {
 	)
 	c.Assert(err, qt.IsNil)
 
-	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	pkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	c.Assert(err, qt.IsNil)
 
 	cert, err := client.Certificates.Create(ctx, &CreateCertificateRequest{


### PR DESCRIPTION
These are a lot faster and smaller, so we're preferring this instead.