### PR TITLE
Enforce TLS 1.2 as the minimum version for client

### DIFF
--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -127,6 +127,7 @@ func createTLSConfig(
 
 	return remoteAddr, &tls.Config{
 		RootCAs:      rootCertPool,
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert.ClientCert},
 		ServerName:   serverName,
 		// We need to set InsecureSkipVerify to true due to


### PR DESCRIPTION
Server side this is already enforced but good to do on the client as well. 