### PR TITLE
Handle multiple CA certs

### DIFF
--- a/planetscale/certs_test.go
+++ b/planetscale/certs_test.go
@@ -127,7 +127,7 @@ func TestCertificates_Create(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(cert.RemoteAddr, qt.Equals, remoteAddr)
-	c.Assert(cert.CACert, qt.Not(qt.IsNil))
+	c.Assert(cert.CACerts, qt.HasLen, 1)
 	c.Assert(cert.ClientCert, qt.Not(qt.IsNil))
 	c.Assert(cert.ClientCert.PrivateKey, qt.Not(qt.IsNil))
 	c.Assert(cert.ClientCert.Certificate, qt.HasLen, 1)
@@ -136,7 +136,7 @@ func TestCertificates_Create(t *testing.T) {
 	ct, err := x509.ParseCertificate(ccert)
 	c.Assert(err, qt.IsNil)
 	c.Assert(ct.Subject.CommonName, qt.Equals, "org-foo/db-foo/branch-foo")
-	c.Assert(ct.Issuer.CommonName, qt.Equals, cert.CACert.Issuer.CommonName)
+	c.Assert(ct.Issuer.CommonName, qt.Equals, cert.CACerts[0].Issuer.CommonName)
 
 	c.Assert(cert.Ports.MySQL, qt.Equals, 3306)
 	c.Assert(cert.Ports.Proxy, qt.Equals, 3307)

--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -120,7 +120,9 @@ func createTLSConfig(
 	}
 
 	rootCertPool := x509.NewCertPool()
-	rootCertPool.AddCert(cert.CACert)
+	for _, caCert := range cert.CACerts {
+		rootCertPool.AddCert(caCert)
+	}
 
 	serverName := fmt.Sprintf("%s.%s.%s.%s", cfg.Branch, cfg.Database, cfg.Organization, cert.RemoteAddr)
 	remoteAddr := net.JoinHostPort(serverName, strconv.Itoa(cert.Ports.MySQL))

--- a/planetscale/dbutil/dbutil_test.go
+++ b/planetscale/dbutil/dbutil_test.go
@@ -120,7 +120,7 @@ func TestCreateTLSConfig(t *testing.T) {
 
 			return &planetscale.Cert{
 				ClientCert: clientCert,
-				CACert:     caCert,
+				CACerts:    []*x509.Certificate{caCert},
 				RemoteAddr: remoteAddr,
 				Ports: planetscale.RemotePorts{
 					MySQL: port,


### PR DESCRIPTION
The API might want to return multiple CAs in the response as multiple PEM encoded certificates. This adds support for handling multiple CAs so we can also change / rotate these if we need to.