### PR TITLE
Update ServiceTokenAccess.ID struct from int to string

### DIFF
--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -140,7 +140,7 @@ type serviceTokensResponse struct {
 }
 
 type ServiceTokenAccess struct {
-	ID       int      `json:"id"`
+	ID       string   `json:"id"`
 	Access   string   `json:"access"`
 	Type     string   `json:"type"`
 	Resource Database `json:"resource"`

--- a/planetscale/service_tokens_test.go
+++ b/planetscale/service_tokens_test.go
@@ -96,7 +96,7 @@ func TestServiceTokens_GetAccess(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"type":"list","next_page":null,"prev_page":null,"data":[{"id":9,"type":"DatabaseAccess","resource":{"id":"1lbjwnp48b6r","type":"Database","url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209","branches_url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209/branches","name":"hidden-river-4209","notes":"","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"},"access":"read_comment"}]}`
+		out := `{"type":"list","next_page":null,"prev_page":null,"data":[{"id":"hjqui654yu71","type":"DatabaseAccess","resource":{"id":"1lbjwnp48b6r","type":"Database","url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209","branches_url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209/branches","name":"hidden-river-4209","notes":"","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"},"access":"read_comment"}]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -112,7 +112,7 @@ func TestServiceTokens_GetAccess(t *testing.T) {
 	})
 	want := []*ServiceTokenAccess{
 		{
-			ID:     9,
+			ID:     "hjqui654yu71",
 			Access: "read_comment",
 			Type:   "DatabaseAccess",
 			Resource: Database{
@@ -139,7 +139,7 @@ func TestServiceTokens_AddAccess(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(data, qt.DeepEquals, wantBody)
 
-		out := `{"type":"list","next_page":null,"prev_page":null,"data":[{"id":9,"type":"DatabaseAccess","resource":{"id":"1lbjwnp48b6r","type":"Database","url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209","branches_url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209/branches","name":"hidden-river-4209","notes":"","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"},"access":"read_comment"}]}`
+		out := `{"type":"list","next_page":null,"prev_page":null,"data":[{"id":"hjqui654yu71","type":"DatabaseAccess","resource":{"id":"1lbjwnp48b6r","type":"Database","url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209","branches_url":"http://api.planetscaledb.local:3000/v1/organizations/organization5/databases/hidden-river-4209/branches","name":"hidden-river-4209","notes":"","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"},"access":"read_comment"}]}`
 		_, err = w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -157,7 +157,7 @@ func TestServiceTokens_AddAccess(t *testing.T) {
 	})
 	want := []*ServiceTokenAccess{
 		{
-			ID:     9,
+			ID:     "hjqui654yu71",
 			Access: "read_comment",
 			Type:   "DatabaseAccess",
 			Resource: Database{


### PR DESCRIPTION
A change to the API is causing errors when creating `service-tokens`
```go
~$ pscale service-token add-access te2okcpjdb5t connect_branch --database again
Error: json: cannot unmarshal string into Go struct field ServiceTokenAccess.data.id of type int
~$ pscale service-token show-access te2okcpjdb5t
Error: json: cannot unmarshal string into Go struct field ServiceTokenAccess.data.id of type int
```

This PR updates the ServiceTokenAccees struct from an `int` to a `string`. 