### PR TITLE
Add audit-log service endpoint

### DIFF
--- a/planetscale/audit_logs.go
+++ b/planetscale/audit_logs.go
@@ -1,0 +1,86 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var _ AuditLogsService = &auditlogsService{}
+
+// AuditLogsService is an interface for communicating with the PlanetScale
+// AuditLogs API endpoints.
+type AuditLogsService interface {
+	List(context.Context, *ListAuditLogsRequest) ([]*AuditLog, error)
+}
+
+// ListAuditLogsRequest encapsulates the request for listing the audit logs of
+// an organization.
+type ListAuditLogsRequest struct {
+	Organization string
+}
+
+// AuditLog represents a PlanetScale audit log.
+type AuditLog struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+
+	ActorID          string `json:"actor_id"`
+	ActorType        string `json:"actor_type"`
+	ActorDisplayName string `json:"actor_display_name"`
+
+	AuditableID          string `json:"auditable_id"`
+	AuditableType        string `json:"auditable_type"`
+	AuditableDisplayName string `json:"auditable_display_name"`
+
+	AuditAction string `json:"audit_action"`
+	Action      string `json:"action"`
+
+	Location string `json:"location"`
+	RemoteIP string `json:"remote_ip"`
+
+	TargetID          string `json:"target_id"`
+	TargetType        string `json:"target_type"`
+	TargetDisplayName string `json:"target_display_name"`
+
+	Metadata map[string]string `json:"metadata"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type auditlogsResponse struct {
+	AuditLogs []*AuditLog `json:"data"`
+}
+
+type auditlogsService struct {
+	client *Client
+}
+
+func NewAuditLogsService(client *Client) *auditlogsService {
+	return &auditlogsService{
+		client: client,
+	}
+}
+
+// List returns the audit logs for an organization.
+func (o *auditlogsService) List(ctx context.Context, listReq *ListAuditLogsRequest) ([]*AuditLog, error) {
+	req, err := o.client.newRequest(http.MethodGet, auditlogsAPIPath(listReq.Organization), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request for listing audit logs")
+	}
+
+	resp := &auditlogsResponse{}
+	if err := o.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.AuditLogs, nil
+}
+
+func auditlogsAPIPath(org string) string {
+	return fmt.Sprintf("%s/%s/audit-log", organizationsAPIPath, org)
+}

--- a/planetscale/audit_logs_test.go
+++ b/planetscale/audit_logs_test.go
@@ -56,6 +56,10 @@ func TestAuditLogs_List(t *testing.T) {
 
 	auditLogs, err := client.AuditLogs.List(ctx, &ListAuditLogsRequest{
 		Organization: testOrg,
+		Events: []AuditLogEvent{
+			AuditLogEventBranchDeleted,
+			AuditLogEventOrganizationJoined,
+		},
 	})
 
 	want := []*AuditLog{

--- a/planetscale/audit_logs_test.go
+++ b/planetscale/audit_logs_test.go
@@ -1,0 +1,89 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAuditLogs_List(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{
+  "type": "list",
+  "next_page": "https://api.planetscale.com/v1/organizations/planetscale/audit-log?page=2",
+  "prev_page": null,
+  "data": [
+    {
+      "id": "ecxuvovgfo95",
+      "type": "AuditLogEvent",
+      "actor_id": "d4hkujnkswjk",
+      "actor_type": "User",
+      "auditable_id": "kbog8qlq6lp4",
+      "auditable_type": "DeployRequest",
+      "target_id": "m40xz7x6gvvk",
+      "target_type": "Database",
+      "location": "Chicago, IL",
+      "target_display_name": "planetscale",
+      "metadata": {
+        "from": "add-name-to-service-tokens",
+        "into": "main"
+      },
+      "audit_action": "deploy_request.queued",
+      "action": "queued",
+      "actor_display_name": "Elom Gomez",
+      "auditable_display_name": "deploy request #102",
+      "remote_ip": "45.19.24.124",
+      "created_at": "2021-07-19T17:13:45.000Z",
+      "updated_at": "2021-07-19T17:13:45.000Z"
+    }
+  ]
+}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	auditLogs, err := client.AuditLogs.List(ctx, &ListAuditLogsRequest{
+		Organization: testOrg,
+	})
+
+	want := []*AuditLog{
+		{
+			ID:                "ecxuvovgfo95",
+			Type:              "AuditLogEvent",
+			ActorID:           "d4hkujnkswjk",
+			ActorType:         "User",
+			AuditableID:       "kbog8qlq6lp4",
+			AuditableType:     "DeployRequest",
+			TargetID:          "m40xz7x6gvvk",
+			TargetType:        "Database",
+			Location:          "Chicago, IL",
+			TargetDisplayName: "planetscale",
+			Metadata: map[string]string{
+				"from": "add-name-to-service-tokens",
+				"into": "main",
+			},
+			AuditAction:          "deploy_request.queued",
+			Action:               "queued",
+			ActorDisplayName:     "Elom Gomez",
+			AuditableDisplayName: "deploy request #102",
+			RemoteIP:             "45.19.24.124",
+			CreatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
+			UpdatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
+		},
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(auditLogs, qt.DeepEquals, want)
+}

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -38,6 +38,7 @@ type Client struct {
 	// base URL for the API
 	baseURL *url.URL
 
+	AuditLogs        AuditLogsService
 	Backups          BackupsService
 	Databases        DatabasesService
 	Certificates     CertificatesService
@@ -131,6 +132,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 		}
 	}
 
+	c.AuditLogs = &auditlogsService{client: c}
 	c.Backups = &backupsService{client: c}
 	c.Databases = &databasesService{client: c}
 	c.Certificates = &certificatesService{client: c}

--- a/planetscale/integration_test.go
+++ b/planetscale/integration_test.go
@@ -74,10 +74,7 @@ func TestIntegration_Databases_List(t *testing.T) {
 
 	_, err = client.Databases.Create(ctx, &CreateDatabaseRequest{
 		Organization: org,
-		Database: &Database{
-			Name:  dbName,
-			Notes: "This is a test DB created from the planetscale-go API library",
-		},
+		Name:         dbName,
 	})
 	if err != nil {
 		t.Fatalf("create database failed: %s", err)
@@ -101,11 +98,44 @@ func TestIntegration_Databases_List(t *testing.T) {
 		fmt.Printf("Notes: %q\n", db.Notes)
 	}
 
-	_, err = client.Databases.Delete(ctx, &DeleteDatabaseRequest{
+	err = client.Databases.Delete(ctx, &DeleteDatabaseRequest{
 		Organization: org,
 		Database:     dbName,
 	})
 	if err != nil {
 		t.Fatalf("delete database failed: %s", err)
 	}
+}
+
+func TestIntegration_AuditLogs_List(t *testing.T) {
+	token := os.Getenv("PLANETSCALE_TOKEN")
+	if token == "" {
+		t.Fatalf("PLANETSCALE_TOKEN is not set")
+	}
+
+	org := os.Getenv("PLANETSCALE_ORG")
+	if org == "" {
+		t.Fatalf("PLANETSCALE_ORG is not set")
+	}
+
+	ctx := context.Background()
+
+	client, err := NewClient(
+		WithAccessToken(token),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	auditLogs, err := client.AuditLogs.List(ctx, &ListAuditLogsRequest{
+		Organization: org,
+	})
+	if err != nil {
+		t.Fatalf("get audit logs failed: %s", err)
+	}
+
+	for _, l := range auditLogs {
+		fmt.Printf("l = %+v\n", l)
+	}
+	fmt.Printf("len(auditLogs) = %+v\n", len(auditLogs))
 }

--- a/planetscale/integration_test.go
+++ b/planetscale/integration_test.go
@@ -129,13 +129,17 @@ func TestIntegration_AuditLogs_List(t *testing.T) {
 
 	auditLogs, err := client.AuditLogs.List(ctx, &ListAuditLogsRequest{
 		Organization: org,
+		Events: []AuditLogEvent{
+			AuditLogEventBranchDeleted,
+			AuditLogEventOrganizationJoined,
+		},
 	})
 	if err != nil {
 		t.Fatalf("get audit logs failed: %s", err)
 	}
 
 	for _, l := range auditLogs {
-		fmt.Printf("l = %+v\n", l)
+		fmt.Printf("l. = %+v\n", l.AuditAction)
 	}
 	fmt.Printf("len(auditLogs) = %+v\n", len(auditLogs))
 }


### PR DESCRIPTION
This PR adds the `AuditogsService` to retrieve a set of audit logs.

```
type AuditLogsService interface {
	List(context.Context, *ListAuditLogsRequest) ([]*AuditLog, error)
}
```

As an example, to list the audit logs for an organization for specific kind of event types, you would use it in this form:

```go
	auditLogs, err := client.AuditLogs.List(ctx, &ListAuditLogsRequest{
		Organization: org,
		Events: []AuditLogEvent{
			AuditLogEventBranchDeleted,
			AuditLogEventOrganizationJoined,
		},
	})
	if err != nil {
		t.Fatalf("get audit logs failed: %s", err)
	}

	for _, log := range auditLogs {
		fmt.Printf("log = %+v\n", log)
	}
```

Note: The Go SDK doesn't support paginating yet. We're going to work on it with a follow-up PR because it affects the new `AuditLogsService` endpoint and other current endpoints in the SDK.