### PR TITLE
Fix dbutil generated key type

### DIFF
--- a/planetscale/dbutil/dbutil.go
+++ b/planetscale/dbutil/dbutil.go
@@ -41,11 +41,7 @@ type DialConfig struct {
 }
 
 func generateKey() (crypto.PrivateKey, error) {
-	pkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-	return &pkey, nil
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }
 
 // Dial creates a secure connection to a PlanetScale database with the given

--- a/planetscale/dbutil/dbutil_test.go
+++ b/planetscale/dbutil/dbutil_test.go
@@ -2,6 +2,8 @@ package dbutil
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -171,4 +173,14 @@ func parseCert(pemCert string) (*x509.Certificate, error) {
 		return nil, errors.New("invalid PEM: " + pemCert)
 	}
 	return x509.ParseCertificate(bl.Bytes)
+}
+
+func Test_generateKey(t *testing.T) {
+	key, _ := generateKey()
+	switch key.(type) {
+	case *rsa.PrivateKey:
+	case *ecdsa.PrivateKey:
+	default:
+		t.Fatal("generated key is not one of ECDSA or RSA private keys")
+	}
 }

--- a/planetscale/dbutil/dbutil_test.go
+++ b/planetscale/dbutil/dbutil_test.go
@@ -3,7 +3,6 @@ package dbutil
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -175,12 +174,15 @@ func parseCert(pemCert string) (*x509.Certificate, error) {
 	return x509.ParseCertificate(bl.Bytes)
 }
 
-func Test_generateKey(t *testing.T) {
-	key, _ := generateKey()
-	switch key.(type) {
-	case *rsa.PrivateKey:
-	case *ecdsa.PrivateKey:
-	default:
-		t.Fatal("generated key is not one of ECDSA or RSA private keys")
+func TestGenerateKey(t *testing.T) {
+	key, err := generateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := key.(*ecdsa.PrivateKey)
+
+	if !ok {
+		t.Fatal("generated key is not an ECDSA private key")
 	}
 }


### PR DESCRIPTION
 https://github.com/planetscale/planetscale-go/blob/main/planetscale/certs.go#L63 asserts PrivateKey within `*rsa.PrivateKey` and `*ecdsa.PrivateKey`, but the original `generateKey()` generates `**ecdsa.PrivateKey`.