### PR TITLE
Revert "Move to the full access host instead of the remote addr"

### DIFF
--- a/planetscale/certs.go
+++ b/planetscale/certs.go
@@ -31,7 +31,7 @@ type CertificatesService interface {
 type Cert struct {
 	ClientCert tls.Certificate
 	CACerts    []*x509.Certificate
-	AccessHost string
+	RemoteAddr string
 	Ports      RemotePorts
 }
 
@@ -103,7 +103,7 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 	var cr struct {
 		Certificate      string         `json:"certificate"`
 		CertificateChain string         `json:"certificate_chain"`
-		AccessHost       string         `json:"access_host"`
+		RemoteAddr       string         `json:"remote_addr"`
 		Ports            map[string]int `json:"ports"`
 	}
 
@@ -137,7 +137,7 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 	return &Cert{
 		ClientCert: clientCert,
 		CACerts:    caCerts,
-		AccessHost: cr.AccessHost,
+		RemoteAddr: cr.RemoteAddr,
 		Ports: RemotePorts{
 			Proxy: cr.Ports["proxy"],
 			MySQL: cr.Ports["mysql-tls"],

--- a/planetscale/certs_test.go
+++ b/planetscale/certs_test.go
@@ -89,7 +89,7 @@ func TestCertificates_Create(t *testing.T) {
 	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	c.Assert(err, qt.IsNil)
 
-	accessHost := "db.foo.example.com"
+	remoteAddr := "foo.example.com"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
@@ -97,12 +97,12 @@ func TestCertificates_Create(t *testing.T) {
 		var out = struct {
 			Certificate      string         `json:"certificate"`
 			CertificateChain string         `json:"certificate_chain"`
-			AccessHost       string         `json:"access_host"`
+			RemoteAddr       string         `json:"remote_addr"`
 			Ports            map[string]int `json:"ports"`
 		}{
 			Certificate:      testSignedPublicKey,
 			CertificateChain: testCACert,
-			AccessHost:       accessHost,
+			RemoteAddr:       remoteAddr,
 			Ports: map[string]int{
 				"mysql-tls": 3306,
 				"proxy":     3307,
@@ -126,7 +126,7 @@ func TestCertificates_Create(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(cert.AccessHost, qt.Equals, accessHost)
+	c.Assert(cert.RemoteAddr, qt.Equals, remoteAddr)
 	c.Assert(cert.CACerts, qt.HasLen, 1)
 	c.Assert(cert.ClientCert, qt.Not(qt.IsNil))
 	c.Assert(cert.ClientCert.PrivateKey, qt.Not(qt.IsNil))


### PR DESCRIPTION
Reverts planetscale/planetscale-go#85
The necessary change in the backend systems didn't go through, need to revert this for now.