### PR TITLE
Support restoring a backup to a new branch

### DIFF
--- a/planetscale/backups.go
+++ b/planetscale/backups.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Backup struct {
+	PublicID    string    `json:"id"`
 	Name        string    `json:"name"`
 	State       string    `json:"state"`
 	Size        int64     `json:"size"`

--- a/planetscale/backups_test.go
+++ b/planetscale/backups_test.go
@@ -37,6 +37,7 @@ func TestBackups_Create(t *testing.T) {
 	})
 
 	want := &Backup{
+		PublicID:  "planetscale-go-test-backup",
 		Name:      testBackup,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
@@ -71,6 +72,7 @@ func TestBackups_List(t *testing.T) {
 	})
 
 	want := []*Backup{{
+		PublicID:  "planetscale-go-test-backup",
 		Name:      testBackup,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
@@ -134,6 +136,7 @@ func TestBackups_Get(t *testing.T) {
 	})
 
 	want := &Backup{
+		PublicID:  "planetscale-go-test-backup",
 		Name:      testBackup,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -33,6 +33,7 @@ type CreateDatabaseBranchRequest struct {
 	Region       string `json:"region,omitempty"`
 	Name         string `json:"name"`
 	ParentBranch string `json:"parent_branch"`
+	BackupID     string `json:"backup_id,omitempty"`
 }
 
 // ListDatabaseBranchesRequest encapsulates the request for listing the branches


### PR DESCRIPTION
Add backup public ID to the create branch JSON payload so it can be used to restore a backup from the command line.