### PR TITLE
Use interface{} instead of string for metadata.

### DIFF
--- a/planetscale/audit_logs.go
+++ b/planetscale/audit_logs.go
@@ -79,7 +79,7 @@ type AuditLog struct {
 	TargetType        string `json:"target_type"`
 	TargetDisplayName string `json:"target_display_name"`
 
-	Metadata map[string]string `json:"metadata"`
+	Metadata map[string]interface{} `json:"metadata"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/planetscale/audit_logs_test.go
+++ b/planetscale/audit_logs_test.go
@@ -74,7 +74,7 @@ func TestAuditLogs_List(t *testing.T) {
 			TargetType:        "Database",
 			Location:          "Chicago, IL",
 			TargetDisplayName: "planetscale",
-			Metadata: map[string]string{
+			Metadata: map[string]interface{}{
 				"from": "add-name-to-service-tokens",
 				"into": "main",
 			},


### PR DESCRIPTION
This pull request changes the audit log type for metadata to be a `map[string]interface{}` instead of map[string]string`. This is because we may have an array type instead of a string returned as one of the keys within this, so this will allow us to support both.