### PR TITLE
Add deploy check errors to deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/frankban/quicktest v1.13.0
-	github.com/go-sql-driver/mysql v1.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -94,6 +94,7 @@ type Deployment struct {
 	ID                   string              `json:"id"`
 	State                string              `json:"state"`
 	Deployable           bool                `json:"deployable"`
+	DeployCheckErrors    string              `json:"deploy_check_errors"`
 	DeployRequestNumber  uint64              `json:"deploy_request_number"`
 	IntoBranch           string              `json:"into_branch"`
 	PrecedingDeployments []*QueuedDeployment `json:"preceding_deployments"`


### PR DESCRIPTION
We should be able to return `deploy_check_errors` from the deployment API in our SDK as well. 