### PR TITLE
licensed: use latest Go on bullseye

### DIFF
--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster
+FROM golang:1.17-bullseye
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev


### PR DESCRIPTION
This is https://github.com/planetscale/cli/pull/451 but for this repo, which should fix licensed builds. 