### PR TITLE
Add omit empty for role in creating a password

### DIFF
--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -38,7 +38,7 @@ type DatabaseBranchPasswordRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
-	Role         string `json:"role"`
+	Role         string `json:"role,omitempty"`
 	DisplayName  string `json:"display_name"`
 }
 


### PR DESCRIPTION
If it's empty, we don't want to send over an empty string.