### PR TITLE
Update Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/planetscale/planetscale-go
 
-go 1.15
+go 1.18
 
 require (
 	github.com/frankban/quicktest v1.14.3


### PR DESCRIPTION
We want to support the latest of `1.18` for Go.