### PR TITLE
Support "Suggested Plan" when importing a database.

### DIFF
--- a/planetscale/imports.go
+++ b/planetscale/imports.go
@@ -12,7 +12,7 @@ import (
 type BillingPlan int
 
 const (
-	DeveloperPlan BillingPlan = iota
+	HobbyPlan BillingPlan = iota
 	ScalerPlan
 )
 
@@ -27,7 +27,7 @@ func (bp BillingPlan) String() string {
 
 var planToBillingPlanMap = map[string]BillingPlan{
 	"scaler":    ScalerPlan,
-	"developer": DeveloperPlan,
+	"developer": HobbyPlan,
 }
 
 type DataImportSource struct {


### PR DESCRIPTION
This PR adds a `SuggestedPlan` property to the response from `TestDataImportSourceResponse` so we can drive the CLI to show appropriate notices when importing a large database into PlanetScale.