### PR TITLE
Add deploy request reverts

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -26,8 +26,8 @@ type DeployRequestsService interface {
 	Diff(ctx context.Context, diffReq *DiffRequest) ([]*Diff, error)
 	Get(context.Context, *GetDeployRequestRequest) (*DeployRequest, error)
 	List(context.Context, *ListDeployRequestsRequest) ([]*DeployRequest, error)
-	SkipRevertDeploy(context.Context, *SkipRevertDeployRequest) (*DeployRequest, error)
-	RevertDeploy(context.Context, *RevertDeployRequest) (*DeployRequest, error)
+	SkipRevertDeploy(context.Context, *SkipRevertDeployRequestRequest) (*DeployRequest, error)
+	RevertDeploy(context.Context, *RevertDeployRequestRequest) (*DeployRequest, error)
 }
 
 // DeployRequestReview posts a review to a deploy request.
@@ -158,13 +158,13 @@ type CreateDeployRequestRequest struct {
 	Notes        string `json:"notes"`
 }
 
-type SkipRevertDeployRequest struct {
+type SkipRevertDeployRequestRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Number       uint64 `json:"-"`
 }
 
-type RevertDeployRequest struct {
+type RevertDeployRequestRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Number       uint64 `json:"-"`
@@ -305,7 +305,7 @@ func (d *deployRequestsService) CancelDeploy(ctx context.Context, deployReq *Can
 }
 
 // SkipRevert skips a pending revert of a completed deploy request
-func (d *deployRequestsService) SkipRevertDeploy(ctx context.Context, deployReq *SkipRevertDeployRequest) (*DeployRequest, error) {
+func (d *deployRequestsService) SkipRevertDeploy(ctx context.Context, deployReq *SkipRevertDeployRequestRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "skip-revert")
 	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
 	if err != nil {
@@ -321,7 +321,7 @@ func (d *deployRequestsService) SkipRevertDeploy(ctx context.Context, deployReq 
 }
 
 // RevertDeploy reverts a completed deploy request
-func (d *deployRequestsService) RevertDeploy(ctx context.Context, deployReq *RevertDeployRequest) (*DeployRequest, error) {
+func (d *deployRequestsService) RevertDeploy(ctx context.Context, deployReq *RevertDeployRequestRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "revert")
 	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
 	if err != nil {

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -26,6 +26,7 @@ type DeployRequestsService interface {
 	Diff(ctx context.Context, diffReq *DiffRequest) ([]*Diff, error)
 	Get(context.Context, *GetDeployRequestRequest) (*DeployRequest, error)
 	List(context.Context, *ListDeployRequestsRequest) ([]*DeployRequest, error)
+	SkipRevert(context.Context, *SkipDeploymentRevert) (*DeployRequest, error)
 }
 
 // DeployRequestReview posts a review to a deploy request.
@@ -156,6 +157,12 @@ type CreateDeployRequestRequest struct {
 	Notes        string `json:"notes"`
 }
 
+type SkipDeploymentRevert struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Number       uint64 `json:"-"`
+}
+
 type ReviewDeployRequestRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
@@ -277,6 +284,22 @@ func (d *deployRequestsService) Create(ctx context.Context, createReq *CreateDep
 // CancelDeploy cancels a queued deploy request.
 func (d *deployRequestsService) CancelDeploy(ctx context.Context, deployReq *CancelDeployRequestRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "cancel")
+	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating http request")
+	}
+
+	dr := &DeployRequest{}
+	if err := d.client.do(ctx, req, &dr); err != nil {
+		return nil, err
+	}
+
+	return dr, nil
+}
+
+// SkipRevert skips a pending revert of a completed deploy request
+func (d *deployRequestsService) SkipRevert(ctx context.Context, deployReq *SkipDeploymentRevert) (*DeployRequest, error) {
+	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "skip-revert")
 	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating http request")

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -298,7 +298,7 @@ func TestDeployRequests_SkipRevertDeploy(t *testing.T) {
 
 	ctx := context.Background()
 
-	dr, err := client.DeployRequests.SkipRevertDeploy(ctx, &SkipRevertDeployRequest{
+	dr, err := client.DeployRequests.SkipRevertDeploy(ctx, &SkipRevertDeployRequestRequest{
 		Organization: "test-organization",
 		Database:     "test-database",
 		Number:       1337,
@@ -339,7 +339,7 @@ func TestDeployRequests_RevertDeploy(t *testing.T) {
 
 	ctx := context.Background()
 
-	dr, err := client.DeployRequests.RevertDeploy(ctx, &RevertDeployRequest{
+	dr, err := client.DeployRequests.RevertDeploy(ctx, &RevertDeployRequestRequest{
 		Organization: "test-organization",
 		Database:     "test-database",
 		Number:       1337,

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -283,7 +283,7 @@ func TestDeployRequests_List(t *testing.T) {
 	c.Assert(requests, qt.DeepEquals, want)
 }
 
-func TestDeployRequests_SkipRevert(t *testing.T) {
+func TestDeployRequests_SkipRevertDeploy(t *testing.T) {
 	c := qt.New(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -298,7 +298,7 @@ func TestDeployRequests_SkipRevert(t *testing.T) {
 
 	ctx := context.Background()
 
-	dr, err := client.DeployRequests.SkipRevert(ctx, &SkipDeploymentRevert{
+	dr, err := client.DeployRequests.SkipRevertDeploy(ctx, &SkipRevertDeployRequest{
 		Organization: "test-organization",
 		Database:     "test-database",
 		Number:       1337,
@@ -311,6 +311,47 @@ func TestDeployRequests_SkipRevert(t *testing.T) {
 		Branch: "development",
 		Deployment: &Deployment{
 			State: "complete",
+		},
+		IntoBranch: "some-branch",
+		Number:     1337,
+		Notes:      "",
+		CreatedAt:  testTime,
+		UpdatedAt:  testTime,
+		ClosedAt:   &testTime,
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dr, qt.DeepEquals, want)
+}
+
+func TestDeployRequests_RevertDeploy(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": "2021-01-14T10:19:23.000Z", "deployment": { "state": "complete_revert" }, "number": 1337}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	dr, err := client.DeployRequests.RevertDeploy(ctx, &RevertDeployRequest{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+	})
+
+	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC)
+
+	want := &DeployRequest{
+		ID:     "test-deploy-request-id",
+		Branch: "development",
+		Deployment: &Deployment{
+			State: "complete_revert",
 		},
 		IntoBranch: "some-branch",
 		Number:     1337,

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -282,3 +282,44 @@ func TestDeployRequests_List(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(requests, qt.DeepEquals, want)
 }
+
+func TestDeployRequests_SkipRevert(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": "2021-01-14T10:19:23.000Z", "deployment": { "state": "complete" }, "number": 1337}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	dr, err := client.DeployRequests.SkipRevert(ctx, &SkipDeploymentRevert{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+	})
+
+	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC)
+
+	want := &DeployRequest{
+		ID:     "test-deploy-request-id",
+		Branch: "development",
+		Deployment: &Deployment{
+			State: "complete",
+		},
+		IntoBranch: "some-branch",
+		Number:     1337,
+		Notes:      "",
+		CreatedAt:  testTime,
+		UpdatedAt:  testTime,
+		ClosedAt:   &testTime,
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dr, qt.DeepEquals, want)
+}


### PR DESCRIPTION
This PR adds support for deploy request reverts:
- skip a revert for a completed deploy request
- complete a revert for a completed deploy request