### PR TITLE
Handle database deletion requests

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -230,8 +230,14 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 		}
 	}
 
-	// this means we don't care about unmrarshaling the response body into v
+	// this means we don't care about unmarshaling the response body into v
 	if v == nil {
+		return nil
+	}
+
+	// We want to overwrite v and make it `nil` if the response body is empty.
+	if res.StatusCode == http.StatusNoContent {
+		v = nil
 		return nil
 	}
 

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -231,13 +231,7 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 	}
 
 	// this means we don't care about unmarshaling the response body into v
-	if v == nil {
-		return nil
-	}
-
-	// We want to overwrite v and make it `nil` if the response body is empty.
-	if res.StatusCode == http.StatusNoContent {
-		v = nil
+	if v == nil || res.StatusCode == http.StatusNoContent {
 		return nil
 	}
 

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -67,6 +67,28 @@ func TestDo(t *testing.T) {
 				Name: "foo-bar",
 			},
 		},
+		{
+			desc:       "returns an HTTP response 204 when deleting a request",
+			statusCode: http.StatusNoContent,
+			method:     http.MethodDelete,
+			response:   "",
+			body:       nil,
+			v:          &Database{},
+			want:       nil,
+		},
+		{
+			desc:       "returns an non-204 HTTP response when deleting a request",
+			statusCode: http.StatusAccepted,
+			method:     http.MethodDelete,
+			response: `{
+			"id": "test"
+			}`,
+			body: nil,
+			v:    &DatabaseDeletionRequest{},
+			want: &DatabaseDeletionRequest{
+				ID: "test",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -76,7 +98,11 @@ func TestDo(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
 
-				_, err := w.Write([]byte(tt.response))
+				res := []byte(tt.response)
+				if tt.response == "" {
+					res = nil
+				}
+				_, err := w.Write(res)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
For certain organizations, users are unable to straight up delete the database and it requires two deletion requests by administrators. This pull request changes the function for `Delete` to return a `DatabaseDeletionRequest`, but if this does not exist, this means that the database was actually deleted for real.

Question:
- Rather than returning the deletion request and exposing an internal concern, should we just return a boolean of sorts instead that stands for whether or not it was actually deleted? 