### PR TITLE
Add cursor-based pagination for audit logs

### DIFF
--- a/planetscale/audit_logs_test.go
+++ b/planetscale/audit_logs_test.go
@@ -17,8 +17,10 @@ func TestAuditLogs_List(t *testing.T) {
 		w.WriteHeader(200)
 		out := `{
   "type": "list",
-  "next_page": "https://api.planetscale.com/v1/organizations/planetscale/audit-log?page=2",
-  "prev_page": null,
+	"has_next": true,
+	"has_prev": false,
+	"cursor_start": "ecxuvovgfo95",
+	"cursor_end": "ecxuvovgfo95",
   "data": [
     {
       "id": "ecxuvovgfo95",
@@ -62,30 +64,36 @@ func TestAuditLogs_List(t *testing.T) {
 		},
 	})
 
-	want := []*AuditLog{
-		{
-			ID:                "ecxuvovgfo95",
-			Type:              "AuditLogEvent",
-			ActorID:           "d4hkujnkswjk",
-			ActorType:         "User",
-			AuditableID:       "kbog8qlq6lp4",
-			AuditableType:     "DeployRequest",
-			TargetID:          "m40xz7x6gvvk",
-			TargetType:        "Database",
-			Location:          "Chicago, IL",
-			TargetDisplayName: "planetscale",
-			Metadata: map[string]interface{}{
-				"from": "add-name-to-service-tokens",
-				"into": "main",
+	want := &CursorPaginatedResponse[*AuditLog]{
+		Data: []*AuditLog{
+			{
+				ID:                "ecxuvovgfo95",
+				Type:              "AuditLogEvent",
+				ActorID:           "d4hkujnkswjk",
+				ActorType:         "User",
+				AuditableID:       "kbog8qlq6lp4",
+				AuditableType:     "DeployRequest",
+				TargetID:          "m40xz7x6gvvk",
+				TargetType:        "Database",
+				Location:          "Chicago, IL",
+				TargetDisplayName: "planetscale",
+				Metadata: map[string]interface{}{
+					"from": "add-name-to-service-tokens",
+					"into": "main",
+				},
+				AuditAction:          "deploy_request.queued",
+				Action:               "queued",
+				ActorDisplayName:     "Elom Gomez",
+				AuditableDisplayName: "deploy request #102",
+				RemoteIP:             "45.19.24.124",
+				CreatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
+				UpdatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
 			},
-			AuditAction:          "deploy_request.queued",
-			Action:               "queued",
-			ActorDisplayName:     "Elom Gomez",
-			AuditableDisplayName: "deploy request #102",
-			RemoteIP:             "45.19.24.124",
-			CreatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
-			UpdatedAt:            time.Date(2021, time.July, 19, 17, 13, 45, 000, time.UTC),
 		},
+		HasNext:     true,
+		HasPrev:     false,
+		CursorStart: "ecxuvovgfo95",
+		CursorEnd:   "ecxuvovgfo95",
 	}
 
 	c.Assert(err, qt.IsNil)

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -345,5 +345,5 @@ type CursorPaginatedResponse[T any] struct {
 	HasNext     bool   `json:"has_next"`
 	HasPrev     bool   `json:"has_prev"`
 	CursorStart string `json:"cursor_start"`
-	CursorEndd  string `json:"cursor_end"`
+	CursorEnd   string `json:"cursor_end"`
 }

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -52,22 +52,42 @@ type Client struct {
 	ServiceTokens    ServiceTokenService
 }
 
-// URLValueOption updates the URL Values with the given options.
-type URLValueOption func(v *url.Values) error
+// ListOptions are options for listing responses.
+type ListOptions struct {
+	URLValues *url.Values
+}
+
+type ListOption func(*ListOptions) error
+
+// DefaultListOptions returns the default list options values.
+func defaultListOptions(opts ...ListOption) *ListOptions {
+	listOpts := &ListOptions{
+		URLValues: &url.Values{},
+	}
+
+	for _, opt := range opts {
+		err := opt(listOpts)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return listOpts
+}
 
 // WithStartingAfter returns a URLValueOption that sets the "starting_after" URL parameter.
-func WithStartingAfter(startingAfter string) URLValueOption {
-	return func(v *url.Values) error {
-		v.Set("starting_after", startingAfter)
+func WithStartingAfter(startingAfter string) ListOption {
+	return func(opt *ListOptions) error {
+		opt.URLValues.Set("starting_after", startingAfter)
 		return nil
 	}
 }
 
 // WithLimit returns a URLValueOption that sets the "limit" URL parameter.
-func WithLimit(limit int) URLValueOption {
-	return func(v *url.Values) error {
+func WithLimit(limit int) ListOption {
+	return func(opt *ListOptions) error {
 		limitStr := strconv.Itoa(limit)
-		v.Set("limit", limitStr)
+		opt.URLValues.Set("limit", limitStr)
 		return nil
 	}
 }

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -337,3 +337,13 @@ type Error struct {
 
 // Error returns the string representation of the error.
 func (e *Error) Error() string { return e.msg }
+
+// CursorPaginatedResponse provides a generic means of wrapping a paginated
+// response.
+type CursorPaginatedResponse[T any] struct {
+	Data        []T    `json:"data"`
+	HasNext     bool   `json:"has_next"`
+	HasPrev     bool   `json:"has_prev"`
+	CursorStart string `json:"cursor_start"`
+	CursorEndd  string `json:"cursor_end"`
+}

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/pkg/errors"
@@ -49,6 +50,26 @@ type Client struct {
 	Regions          RegionsService
 	DeployRequests   DeployRequestsService
 	ServiceTokens    ServiceTokenService
+}
+
+// URLValueOption updates the URL Values with the given options.
+type URLValueOption func(v *url.Values) error
+
+// WithStartingAfter returns a URLValueOption that sets the "starting_after" URL parameter.
+func WithStartingAfter(startingAfter string) URLValueOption {
+	return func(v *url.Values) error {
+		v.Set("starting_after", startingAfter)
+		return nil
+	}
+}
+
+// WithLimit returns a URLValueOption that sets the "limit" URL parameter.
+func WithLimit(limit int) URLValueOption {
+	return func(v *url.Values) error {
+		limitStr := strconv.Itoa(limit)
+		v.Set("limit", limitStr)
+		return nil
+	}
 }
 
 // ClientOption provides a variadic option for configuring the client


### PR DESCRIPTION
This pull request adds cursor-based pagination for our audit logs so that we have a means of returning paginated API responses where necessary. 

Open Questions:
* Should we maybe have a separate, `ListPaginated` API response to keep backwards-compatibility?
* How do we feel about how we're handling variadic options for URL values? I think `ListOptions` could expand to be like `FetchAll` to loop through and fetch every single item rather than relying on pagination, etc.