### PR TITLE
Use `planetscale-go` version as User Agent, also allow users to set custom UAs and headers

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -21,7 +21,7 @@ const (
 )
 
 const (
-	libraryVersion = "v0.108.0"
+	libraryVersion = "v0.67.0"
 	userAgent      = "planetscale-go/" + libraryVersion
 )
 

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -11,16 +11,16 @@ import (
 
 func TestDo(t *testing.T) {
 	tests := []struct {
-		desc           string
-		response       string
-		statusCode     int
-		method         string
-		expectedError  error
-		requestOptions []RequestOption
-		wantHeaders    map[string]string
-		body           interface{}
-		v              interface{}
-		want           interface{}
+		desc          string
+		response      string
+		statusCode    int
+		method        string
+		expectedError error
+		clientOptions []ClientOption
+		wantHeaders   map[string]string
+		body          interface{}
+		v             interface{}
+		want          interface{}
 	}{
 		{
 			desc:       "returns an HTTP response and no error for 2xx responses",
@@ -29,14 +29,14 @@ func TestDo(t *testing.T) {
 			method:     http.MethodGet,
 		},
 		{
-			desc:           "sets a custom header with the request option",
-			statusCode:     http.StatusOK,
-			response:       `{}`,
-			method:         http.MethodGet,
-			requestOptions: []RequestOption{WithUserAgent("test-user-agent"), WithHeader("Test-Header", "test-value")},
+			desc:          "sets a custom header with the request option",
+			statusCode:    http.StatusOK,
+			response:      `{}`,
+			method:        http.MethodGet,
+			clientOptions: []ClientOption{WithUserAgent("test-user-agent"), WithRequestHeaders(map[string]string{"Test-Header": "test-value"})},
 			wantHeaders: map[string]string{
 				"Test-Header": "test-value",
-				"User-Agent":  "test-user-agent",
+				"User-Agent":  "test-user-agent planetscale-go/v0.108.0",
 			},
 		},
 		{
@@ -128,7 +128,8 @@ func TestDo(t *testing.T) {
 			}))
 			t.Cleanup(ts.Close)
 
-			client, err := NewClient(WithBaseURL(ts.URL), WithRequestOptions(tt.requestOptions...))
+			opts := append(tt.clientOptions, WithBaseURL(ts.URL))
+			client, err := NewClient(opts...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -27,6 +27,9 @@ func TestDo(t *testing.T) {
 			statusCode: http.StatusOK,
 			response:   `{}`,
 			method:     http.MethodGet,
+			wantHeaders: map[string]string{
+				"User-Agent": "planetscale-go/v0.108.0",
+			},
 		},
 		{
 			desc:          "sets a custom header with the request option",

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -28,7 +28,7 @@ func TestDo(t *testing.T) {
 			response:   `{}`,
 			method:     http.MethodGet,
 			wantHeaders: map[string]string{
-				"User-Agent": "planetscale-go/v0.108.0",
+				"User-Agent": "planetscale-go/v0.67.0",
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func TestDo(t *testing.T) {
 			clientOptions: []ClientOption{WithUserAgent("test-user-agent"), WithRequestHeaders(map[string]string{"Test-Header": "test-value"})},
 			wantHeaders: map[string]string{
 				"Test-Header": "test-value",
-				"User-Agent":  "test-user-agent planetscale-go/v0.108.0",
+				"User-Agent":  "test-user-agent planetscale-go/v0.67.0",
 			},
 		},
 		{


### PR DESCRIPTION
This pull request will set the version of `planetscale-go` being used on every single request, so we can have visibility into what version of the SDK every user is using. 

This will kind of change up the process a little bit. When drafting a new release, we'll have to remember to update the `libraryVersion`. Or at least, make a PR bumping the version before we cut a new release.