### PR TITLE
Add pagination for listing databases.

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -108,6 +108,28 @@ func WithLimit(limit int) ListOption {
 	}
 }
 
+// WithPage returns a ListOption that sets the "page" URL parameter.
+func WithPage(page int) ListOption {
+	return func(opt *ListOptions) error {
+		if page > 0 {
+			pageStr := strconv.Itoa(page)
+			opt.URLValues.Set("page", pageStr)
+		}
+		return nil
+	}
+}
+
+// WithPerPage returns a ListOption that sets the "per_page" URL paramter.
+func WithPerPage(perPage int) ListOption {
+	return func(opt *ListOptions) error {
+		if perPage > 0 {
+			perPageStr := strconv.Itoa(perPage)
+			opt.URLValues.Set("per_page", perPageStr)
+		}
+		return nil
+	}
+}
+
 // ClientOption provides a variadic option for configuring the client
 type ClientOption func(c *Client) error
 

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -123,6 +123,42 @@ func TestDatabases_List(t *testing.T) {
 	c.Assert(db, qt.DeepEquals, want)
 }
 
+func TestDatabases_ListWithOptions(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"data":[{"id":"planetscale-go-test-db","type":"database", "name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "100")
+
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	name := "planetscale-go-test-db"
+	notes := "This is a test DB created from the planetscale-go API library"
+
+	db, err := client.Databases.List(ctx, &ListDatabasesRequest{
+		Organization: org,
+	}, WithPage(2))
+
+	want := []*Database{{
+		Name:      name,
+		Notes:     notes,
+		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+	}}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.DeepEquals, want)
+}
+
 func TestDatabases_DeleteNoContent(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
This pull request adds pagination for listing databases, in case there are more than 100 for some reason.

I was thinking of changing the return format of the `List` response to be something like this:

```go
// PaginatedResponse provides a generic means of wrapping a paginated response.
type PaginatedResponse[T any] struct {
	Data []T `json:"data"`

	NextPage *int    `json:"next_page"`
	PrevPage *string `json:"prev_page"`
}
```

I know this would be a breaking change, but for an API client, I think this response format makes sense in order to have access to this pagination metadata. I would appreciate others thoughts though.

cc @fatih 