### PR TITLE
add 'host' to password response

### DIFF
--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -24,6 +24,7 @@ type ConnectionStrings struct {
 type DatabaseBranchPassword struct {
 	PublicID          string            `json:"id"`
 	Name              string            `json:"display_name"`
+	Host              string            `json:"access_host_url"`
 	Username          string            `json:"username"`
 	Role              string            `json:"role"`
 	Branch            DatabaseBranch    `json:"database_branch"`

--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -24,7 +24,7 @@ type ConnectionStrings struct {
 type DatabaseBranchPassword struct {
 	PublicID          string            `json:"id"`
 	Name              string            `json:"display_name"`
-	Host              string            `json:"access_host_url"`
+	Hostname              string            `json:"access_host_url"`
 	Username          string            `json:"username"`
 	Role              string            `json:"role"`
 	Branch            DatabaseBranch    `json:"database_branch"`


### PR DESCRIPTION
Parse the 'access_host_url' from create password requests which contains the planetscale host to connect to 

```json
{"type":"BranchPassword","access_host_url":"us-west.connect.psdb.cloud"}
```

closes #115 since the username can be gotten through `Username`