### PR TITLE
Add ability to list service token grants

### DIFF
--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -155,9 +155,11 @@ type ServiceToken struct {
 }
 
 type ServiceTokenGrant struct {
-	ID       string                `json:"id"`
-	Resource Database              `json:"resource"`
-	Accesses []*ServiceTokenAccess `json:"accesses"`
+	ID           string   `json:"id"`
+	ResourceName string   `json:"resource_name"`
+	ResourceType string   `json:"resource_type"`
+	ResourceID   string   `json:"resource_id"`
+	Accesses     []string `json:"accesses"`
 }
 
 type serviceTokensResponse struct {

--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -13,6 +13,7 @@ var _ ServiceTokenService = &serviceTokenService{}
 type ServiceTokenService interface {
 	Create(context.Context, *CreateServiceTokenRequest) (*ServiceToken, error)
 	List(context.Context, *ListServiceTokensRequest) ([]*ServiceToken, error)
+	Get(context.Context, *GetServiceTokenRequest) (*ServiceToken, error)
 	Delete(context.Context, *DeleteServiceTokenRequest) error
 	GetAccess(context.Context, *GetServiceTokenAccessRequest) ([]*ServiceTokenAccess, error)
 	AddAccess(context.Context, *AddServiceTokenAccessRequest) ([]*ServiceTokenAccess, error)
@@ -49,6 +50,20 @@ func (s *serviceTokenService) List(ctx context.Context, listReq *ListServiceToke
 	}
 
 	return tokenListResponse.ServiceTokens, nil
+}
+
+func (s *serviceTokenService) Get(ctx context.Context, getReq *GetServiceTokenRequest) (*ServiceToken, error) {
+	req, err := s.client.newRequest(http.MethodGet, serviceTokenAPIPath(getReq.Organization, getReq.ID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	st := &ServiceToken{}
+	if err := s.client.do(ctx, req, &st); err != nil {
+		return nil, err
+	}
+
+	return st, nil
 }
 
 func (s *serviceTokenService) Delete(ctx context.Context, delReq *DeleteServiceTokenRequest) error {
@@ -99,6 +114,11 @@ func (s *serviceTokenService) DeleteAccess(ctx context.Context, delReq *DeleteSe
 
 type CreateServiceTokenRequest struct {
 	Organization string `json:"-"`
+}
+
+type GetServiceTokenRequest struct {
+	Organization string `json:"-"`
+	ID           string `json:"-"`
 }
 
 type DeleteServiceTokenRequest struct {

--- a/planetscale/service_tokens_test.go
+++ b/planetscale/service_tokens_test.go
@@ -39,6 +39,40 @@ func TestServiceTokens_Create(t *testing.T) {
 	c.Assert(snapshot, qt.DeepEquals, want)
 }
 
+func TestServiceTokens_ListGrants(t *testing.T) {
+	c := qt.New(t)
+
+	out := `{"type":"list","current_page":1,"next_page":null,"next_page_url":null,"prev_page":null,"prev_page_url":null,"data":[{"id":"qbphfi83nxti","type":"ServiceTokenGrant","resource_name":"planetscale","resource_type":"Database","resource_id":"qbphfi83nxti","accesses":["read_branch"]}]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	grants, err := client.ServiceTokens.ListGrants(ctx, &ListServiceTokenGrantsRequest{
+		Organization: testOrg,
+		ID:           "1234",
+	})
+
+	want := []*ServiceTokenGrant{
+		{
+			ID:           "qbphfi83nxti",
+			ResourceName: "planetscale",
+			ResourceType: "Database",
+			ResourceID:   "qbphfi83nxti",
+			Accesses:     []string{"read_branch"},
+		},
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(grants, qt.DeepEquals, want)
+}
+
 func TestServiceTokens_List(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
This pull request adds a method for listing grants for a service token. The difference between this and listing accesses is that we can have access to both the resourcesAND their service token accesses in a single struct, making access for both easier.

TODO:
- [x] Tests