### PR TITLE
Rename Promote function to RequestPromotion

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -99,9 +99,9 @@ type RefreshSchemaRequest struct {
 	Branch       string `json:"-"`
 }
 
-// PromoteRequest encapsulates the request for promoting a branch to
+// RequestPromotionRequest encapsulates the request for promoting a branch to
 // production.
-type PromoteRequest struct {
+type RequestPromotionRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
@@ -163,7 +163,7 @@ type DatabaseBranchesService interface {
 	VSchema(context.Context, *BranchVSchemaRequest) (*VSchemaDiff, error)
 	Keyspaces(context.Context, *BranchKeyspacesRequest) ([]*Keyspace, error)
 	RefreshSchema(context.Context, *RefreshSchemaRequest) error
-	Promote(context.Context, *PromoteRequest) (*BranchPromotionRequest, error)
+	RequestPromotion(context.Context, *RequestPromotionRequest) (*BranchPromotionRequest, error)
 	GetPromotionRequest(context.Context, *GetPromotionRequestRequest) (*BranchPromotionRequest, error)
 }
 
@@ -342,9 +342,9 @@ func (d *databaseBranchesService) RefreshSchema(ctx context.Context, refreshReq 
 	return nil
 }
 
-// PromoteBranch promotes a database's branch from a development branch to a
-// production branch.
-func (d *databaseBranchesService) Promote(ctx context.Context, promoteReq *PromoteRequest) (*BranchPromotionRequest, error) {
+// RequestPromotion requests a branch to be promoted from development to
+// production.
+func (d *databaseBranchesService) RequestPromotion(ctx context.Context, promoteReq *RequestPromotionRequest) (*BranchPromotionRequest, error) {
 	path := fmt.Sprintf("%s/promotion-request", databaseBranchAPIPath(promoteReq.Organization, promoteReq.Database, promoteReq.Branch))
 	req, err := d.client.newRequest(http.MethodPost, path, nil)
 	if err != nil {

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -279,7 +279,7 @@ func TestBranches_RefreshSchema(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
-func TestBranches_Promote(t *testing.T) {
+func TestBranches_RequestPromotion(t *testing.T) {
 	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC)
 	c := qt.New(t)
 
@@ -324,7 +324,7 @@ func TestBranches_Promote(t *testing.T) {
 	org := "my-org"
 	name := "planetscale-go-test-db"
 
-	db, err := client.DatabaseBranches.Promote(ctx, &PromoteRequest{
+	db, err := client.DatabaseBranches.RequestPromotion(ctx, &RequestPromotionRequest{
 		Organization: org,
 		Database:     name,
 		Branch:       "planetscale-go-test-db-branch",


### PR DESCRIPTION
This pull request changes to `RequestPromotion`. The reason is that branch promotion is an async action. `Promote` implies that it is synchronous, `RequestPromotion` more accurately highlights what it is actually doing.