### PR TITLE
Add `omitempty` for deploy request's into branch

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -172,7 +172,7 @@ type CreateDeployRequestRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"branch"`
-	IntoBranch   string `json:"into_branch"`
+	IntoBranch   string `json:"into_branch,omitempty"`
 	Notes        string `json:"notes"`
 }
 


### PR DESCRIPTION
Adds `omitempty` into the `IntoBranch` field so that it does not send over a blank string.