### PR TITLE
[ServiceTokens] Update grant type

### DIFF
--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -155,11 +155,16 @@ type ServiceToken struct {
 }
 
 type ServiceTokenGrant struct {
-	ID           string   `json:"id"`
-	ResourceName string   `json:"resource_name"`
-	ResourceType string   `json:"resource_type"`
-	ResourceID   string   `json:"resource_id"`
-	Accesses     []string `json:"accesses"`
+	ID           string                     `json:"id"`
+	ResourceName string                     `json:"resource_name"`
+	ResourceType string                     `json:"resource_type"`
+	ResourceID   string                     `json:"resource_id"`
+	Accesses     []*ServiceTokenGrantAccess `json:"accesses"`
+}
+
+type ServiceTokenGrantAccess struct {
+	Access      string `json:"access"`
+	Description string `json:"description"`
 }
 
 type serviceTokensResponse struct {

--- a/planetscale/service_tokens_test.go
+++ b/planetscale/service_tokens_test.go
@@ -42,7 +42,7 @@ func TestServiceTokens_Create(t *testing.T) {
 func TestServiceTokens_ListGrants(t *testing.T) {
 	c := qt.New(t)
 
-	out := `{"type":"list","current_page":1,"next_page":null,"next_page_url":null,"prev_page":null,"prev_page_url":null,"data":[{"id":"qbphfi83nxti","type":"ServiceTokenGrant","resource_name":"planetscale","resource_type":"Database","resource_id":"qbphfi83nxti","accesses":["read_branch"]}]}`
+	out := `{"type":"list","current_page":1,"next_page":null,"next_page_url":null,"prev_page":null,"prev_page_url":null,"data":[{"id":"qbphfi83nxti","type":"ServiceTokenGrant","resource_name":"planetscale","resource_type":"Database","resource_id":"qbphfi83nxti","accesses":[{"access": "read_branch", "description": "Read database branch"}]}]}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, err := w.Write([]byte(out))
@@ -65,7 +65,7 @@ func TestServiceTokens_ListGrants(t *testing.T) {
 			ResourceName: "planetscale",
 			ResourceType: "Database",
 			ResourceID:   "qbphfi83nxti",
-			Accesses:     []string{"read_branch"},
+			Accesses:     []*ServiceTokenGrantAccess{{Access: "read_branch"}},
 		},
 	}
 

--- a/planetscale/service_tokens_test.go
+++ b/planetscale/service_tokens_test.go
@@ -65,7 +65,7 @@ func TestServiceTokens_ListGrants(t *testing.T) {
 			ResourceName: "planetscale",
 			ResourceType: "Database",
 			ResourceID:   "qbphfi83nxti",
-			Accesses:     []*ServiceTokenGrantAccess{{Access: "read_branch"}},
+			Accesses:     []*ServiceTokenGrantAccess{{Access: "read_branch", Description: "Read database branch"}},
 		},
 	}
 


### PR DESCRIPTION
This PR updates the grant types to match the updated serializer: https://github.com/planetscale/api-bb/blob/main/app/serializers/service_token_grant_serializer.rb#L21

This with https://github.com/planetscale/cli/pull/616 should fix https://github.com/planetscale/surfaces/issues/912