### PR TITLE
Add Safe Migration and Promote methods

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -487,7 +487,6 @@ func (d *databaseBranchesService) DisableSafeMigrations(ctx context.Context, dis
 	}
 
 	return branch, nil
-
 }
 
 func (d *databaseBranchesService) GetPromotionRequest(ctx context.Context, getReg *GetPromotionRequestRequest) (*BranchPromotionRequest, error) {

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -19,15 +19,16 @@ type Actor struct {
 
 // DatabaseBranch represents a database branch.
 type DatabaseBranch struct {
-	Name          string    `json:"name"`
-	ParentBranch  string    `json:"parent_branch"`
-	Region        Region    `json:"region"`
-	Ready         bool      `json:"ready"`
-	Production    bool      `json:"production"`
-	HtmlURL       string    `json:"html_url"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
-	AccessHostURL string    `json:"access_host_url"`
+	Name           string    `json:"name"`
+	ParentBranch   string    `json:"parent_branch"`
+	Region         Region    `json:"region"`
+	Ready          bool      `json:"ready"`
+	Production     bool      `json:"production"`
+	HtmlURL        string    `json:"html_url"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	AccessHostURL  string    `json:"access_host_url"`
+	SafeMigrations bool      `json:"safe_migrations"`
 }
 
 type databaseBranchesResponse struct {

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -150,7 +150,33 @@ type RequestPromotionRequest struct {
 	Branch       string `json:"-"`
 }
 
+// GetPromotionRequestRequest encapsulates the request for getting a branch
+// promotion request.
 type GetPromotionRequestRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+}
+
+// PromoteRequest encapsulates the request for promoting a request to
+// production.
+type PromoteRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+}
+
+// EnableSafeMigrationsRequest encapsulates the request for enabling safe
+// migrations on a branch.
+type EnableSafeMigrationsRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+}
+
+// DisableSafeMigrationsRequest encapsulates the request for disabling safe
+// migrations on a branch.
+type DisableSafeMigrationsRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
@@ -211,6 +237,9 @@ type DatabaseBranchesService interface {
 	RequestPromotion(context.Context, *RequestPromotionRequest) (*BranchPromotionRequest, error)
 	GetPromotionRequest(context.Context, *GetPromotionRequestRequest) (*BranchPromotionRequest, error)
 	DenyDemotionRequest(context.Context, *DenyDemotionRequestRequest) error
+	Promote(context.Context, *PromoteRequest) (*DatabaseBranch, error)
+	EnableSafeMigrations(context.Context, *EnableSafeMigrationsRequest) (*DatabaseBranch, error)
+	DisableSafeMigrations(context.Context, *DisableSafeMigrationsRequest) (*DatabaseBranch, error)
 }
 
 type databaseBranchesService struct {
@@ -404,6 +433,60 @@ func (d *databaseBranchesService) RequestPromotion(ctx context.Context, promoteR
 	}
 
 	return promotionReq, nil
+}
+
+// Promote promotes a branch from development to production.
+func (d *databaseBranchesService) Promote(ctx context.Context, promoteReq *PromoteRequest) (*DatabaseBranch, error) {
+	path := fmt.Sprintf("%s/promote", databaseBranchAPIPath(promoteReq.Organization, promoteReq.Database, promoteReq.Branch))
+	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request for branch promotion")
+	}
+
+	branch := &DatabaseBranch{}
+	err = d.client.do(ctx, req, &branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return branch, nil
+}
+
+// EnableSafeMigrations enables safe migrations for a production branch. This
+// will prevent DDL statements from being performed on the branch.
+func (d *databaseBranchesService) EnableSafeMigrations(ctx context.Context, enableReq *EnableSafeMigrationsRequest) (*DatabaseBranch, error) {
+	path := fmt.Sprintf("%s/safe-migrations", databaseBranchAPIPath(enableReq.Organization, enableReq.Database, enableReq.Branch))
+	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request for enabling safe migrations")
+	}
+
+	branch := &DatabaseBranch{}
+	err = d.client.do(ctx, req, &branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return branch, nil
+}
+
+// DisableSafeMigrations disables safe migrations for a production branch. This
+// will allow DDL statements to be performed on the branch.
+func (d *databaseBranchesService) DisableSafeMigrations(ctx context.Context, disableReq *DisableSafeMigrationsRequest) (*DatabaseBranch, error) {
+	path := fmt.Sprintf("%s/safe-migrations", databaseBranchAPIPath(disableReq.Organization, disableReq.Database, disableReq.Branch))
+	req, err := d.client.newRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating request for disabling safe migrations")
+	}
+
+	branch := &DatabaseBranch{}
+	err = d.client.do(ctx, req, &branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return branch, nil
+
 }
 
 func (d *databaseBranchesService) GetPromotionRequest(ctx context.Context, getReg *GetPromotionRequestRequest) (*BranchPromotionRequest, error) {

--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -127,7 +127,9 @@ func TestDatabaseBranches_Get(t *testing.T) {
 
 	db, err := client.DatabaseBranches.Get(ctx, &GetDatabaseBranchRequest{
 		Organization: org,
-		Database:     name})
+		Database:     name,
+		Branch:       testBranch,
+	})
 
 	want := &DatabaseBranch{
 		Name:      testBranch,
@@ -588,4 +590,108 @@ func TestBranches_DenyDemotionRequest(t *testing.T) {
 	})
 
 	c.Assert(err, qt.IsNil)
+}
+
+func TestDatabaseBranches_Promote(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z","production": true}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	name := "planetscale-go-test-db"
+
+	db, err := client.DatabaseBranches.Promote(ctx, &PromoteRequest{
+		Organization: org,
+		Database:     name,
+		Branch:       testBranch,
+	})
+
+	want := &DatabaseBranch{
+		Name:       testBranch,
+		Production: true,
+		CreatedAt:  time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+		UpdatedAt:  time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.DeepEquals, want)
+}
+
+func TestDatabaseBranches_EnableSafeMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z","production": true,"safe_migrations":true}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	name := "planetscale-go-test-db"
+
+	db, err := client.DatabaseBranches.EnableSafeMigrations(ctx, &EnableSafeMigrationsRequest{
+		Organization: org,
+		Database:     name,
+		Branch:       testBranch,
+	})
+
+	want := &DatabaseBranch{
+		Name:           testBranch,
+		Production:     true,
+		SafeMigrations: true,
+		CreatedAt:      time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+		UpdatedAt:      time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.DeepEquals, want)
+}
+
+func TestDatabaseBranches_DisableSafeMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z","production": true,"safe_migrations":false}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	name := "planetscale-go-test-db"
+
+	db, err := client.DatabaseBranches.DisableSafeMigrations(ctx, &DisableSafeMigrationsRequest{
+		Organization: org,
+		Database:     name,
+		Branch:       testBranch,
+	})
+
+	want := &DatabaseBranch{
+		Name:           testBranch,
+		Production:     true,
+		SafeMigrations: false,
+		CreatedAt:      time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+		UpdatedAt:      time.Date(2021, time.January, 14, 10, 19, 23, 000, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.DeepEquals, want)
 }


### PR DESCRIPTION
This pull request adds functionality for safe migration endpoints and also our direct promotion flow after we ship Safe Migrations.  This will take the place of DDL protection on production branches.