### PR TITLE
README: clean up example and link pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,74 @@
-# planetscale-go [![Build status](https://badge.buildkite.com/82dafa9518fe94b3fed75db71bcfc3836faeec49816e400f2e.svg?branch=main)](https://buildkite.com/planetscale/planetscale-go)
+# planetscale-go [![Go Reference](https://pkg.go.dev/badge/github.com/planetscale/planetscale-go/planetscale.svg)](https://pkg.go.dev/github.com/planetscale/planetscale-go/planetscale) [![Build status](https://badge.buildkite.com/82dafa9518fe94b3fed75db71bcfc3836faeec49816e400f2e.svg?branch=main)](https://buildkite.com/planetscale/planetscale-go)
 
 Go package to access the PlanetScale API.
 
-
 ## Install
 
-```bash
+```
 go get github.com/planetscale/planetscale-go/planetscale
 ```
 
 ## Usage
 
-Here is an example usage of the PlanetScale Go client. Please make sure to
-handle errors in your production application.
-
+Here is an example application using the PlanetScale Go client. You can create
+and manage your service tokens via our [pscale
+CLI](https://github.com/planetscale/cli) with the `pscale service-token`
+subcommand.
 
 ```go
 package main
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"os"
+	"time"
 
 	"github.com/planetscale/planetscale-go/planetscale"
 )
 
 func main() {
-	token := os.Getenv("PLANETSCALE_TOKEN")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	ctx := context.Background()
-
-	// create a new PlanetScale API client with the given access token
-	client, _ := planetscale.NewClient(
-		planetscale.WithAccessToken(token),
+	// Create a new PlanetScale API client with the given service token.
+	client, err := planetscale.NewClient(
+		planetscale.WithServiceToken("token-id", os.Getenv("PLANETSCALE_TOKEN")),
 	)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
 
-	// create a new database
-	_, err := client.Databases.Create(ctx, &planetscale.CreateDatabaseRequest{
+	// Create a new database.
+	_, err = client.Databases.Create(ctx, &planetscale.CreateDatabaseRequest{
 		Organization: "my-org",
 		Name:         "my-awesome-database",
 		Notes:        "This is a test DB created via the planetscale-go API library",
 	})
-
-	// list all databases for the given organization
-	databases, _ := client.Databases.List(ctx, &planetscale.ListDatabasesRequest{
-		Organization: "my-org",
-	})
-	fmt.Printf("Found %d databases\n", len(databases))
-	for _, db := range databases {
-		fmt.Printf("Name: %q\n", db.Name)
-		fmt.Printf("Notes: %q\n", db.Notes)
+	if err != nil {
+		log.Fatalf("failed to create database: %v", err)
 	}
 
-	// delete a database
-	_ = client.Databases.Delete(ctx, &planetscale.DeleteDatabaseRequest{
+	// List all databases for the given organization.
+	databases, err := client.Databases.List(ctx, &planetscale.ListDatabasesRequest{
+		Organization: "my-org",
+	})
+	if err != nil {
+		log.Fatalf("failed to list databases: %v", err)
+	}
+
+	log.Printf("found %d databases:", len(databases))
+	for _, db := range databases {
+		log.Printf("  - %q: %s", db.Name, db.Notes)
+	}
+
+	// Delete a database.
+	_, err = client.Databases.Delete(ctx, &planetscale.DeleteDatabaseRequest{
 		Organization: "my-org",
 		Database:     "my-awesome-database",
 	})
+	if err != nil {
+		log.Fatalf("failed to delete database: %v", err)
+	}
 }
-```
-
-
-## Using a Service Token 
-
-To use a `service token`, instead of an `access token`, use the
-`planetscale.WithServiceToken()` option function:
-
-```go
-// create a new PlanetScale API client with the given service token. 
-client, _ := planetscale.NewClient(
-	planetscale.WithServiceToken(name, token),
-)
-```
-
-You can create and manage your service tokens via our [pscale
-CLI](https://github.com/planetscale/cli) with the `pscale service-token`
-subcommand.
-
-
-## Use a custom HTTP Client
-
-You can use a custom HTTP Client with the `planetscale.WithHTTPClient()` option
-function:
-
-```go
-httpClient := &http.Client{
-	Timeout: 15 * time.Second,
-}
-
-// create a new PlanetScale API client with the given access token and
-// custom HTTP Client
-client, _ := planetscale.NewClient(
-	planetscale.WithHTTPClient(httpClient),
-	planetscale.WithAccessToken(token),
-)
 ```


### PR DESCRIPTION
The existing example didn't compile or handle errors, we can do better by doing a few small error checks. Switch to service tokens as the old access token method no longer appears to work? Leave the advanced use examples for the godoc.