### PR TITLE
Remove demotion/promotion requests

### DIFF
--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -280,165 +280,12 @@ func TestBranches_RefreshSchema(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
-func TestBranches_RequestPromotion(t *testing.T) {
-	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
+func TestBranches_Demote(t *testing.T) {
 	c := qt.New(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodPost, qt.Equals, r.Method)
 		w.WriteHeader(200)
-
-		out := `
-{
-	"id": "test-promotion-branch",
-	"type": "BranchPromotionRequest",
-	"state": "promoted",
-	"created_at": "2021-01-14T10:19:23.000Z",
-	"updated_at": "2021-01-14T10:19:23.000Z",
-	"started_at": "2021-01-14T10:19:23.000Z",
-	"finished_at": "2021-01-14T10:19:23.000Z",
-	"lint_errors": null,
-	"branch": "main",
-		"actor": {
-			"id": "test-promotion-branch",
-			"type": "User",
-			"display_name": "Test User",
-			"name": "Test User",
-			"nickname": null,
-			"email": "test@example.com",
-			"avatar_url": "https://www.gravatar.com/avatar/4c97310eb2f0e43f486380f040398a02?d=https%3A%2F%2Fapp.planetscale.com%2Fgravatar-fallback.png&s=64",
-			"created_at": "2021-08-25T21:22:20.150Z",
-			"updated_at": "2021-08-26T20:08:14.725Z",
-			"two_factor_auth_configured": false
-		}
-
-}`
-
-		_, err := w.Write([]byte(out))
-		c.Assert(err, qt.IsNil)
-	}))
-
-	client, err := NewClient(WithBaseURL(ts.URL))
-	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
-	org := "my-org"
-	name := "planetscale-go-test-db"
-
-	db, err := client.DatabaseBranches.RequestPromotion(ctx, &RequestPromotionRequest{
-		Organization: org,
-		Database:     name,
-		Branch:       "planetscale-go-test-db-branch",
-	})
-
-	want := &BranchPromotionRequest{
-		ID:         "test-promotion-branch",
-		State:      "promoted",
-		Branch:     "main",
-		CreatedAt:  testTime,
-		UpdatedAt:  testTime,
-		StartedAt:  &testTime,
-		FinishedAt: &testTime,
-	}
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(db, qt.DeepEquals, want)
-}
-
-func TestBranches_GetPromotionRequest(t *testing.T) {
-	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
-	c := qt.New(t)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodGet, qt.Equals, r.Method)
-		w.WriteHeader(200)
-
-		out := `
-{
-	"id": "test-promotion-branch",
-	"type": "BranchPromotionRequest",
-	"state": "promoted",
-	"created_at": "2021-01-14T10:19:23.000Z",
-	"updated_at": "2021-01-14T10:19:23.000Z",
-	"started_at": "2021-01-14T10:19:23.000Z",
-	"finished_at": "2021-01-14T10:19:23.000Z",
-	"lint_errors": null,
-	"branch": "main",
-		"actor": {
-			"id": "test-promotion-branch",
-			"type": "User",
-			"display_name": "Test User",
-			"name": "Test User",
-			"nickname": null,
-			"email": "test@example.com",
-			"avatar_url": "https://www.gravatar.com/avatar/4c97310eb2f0e43f486380f040398a02?d=https%3A%2F%2Fapp.planetscale.com%2Fgravatar-fallback.png&s=64",
-			"created_at": "2021-08-25T21:22:20.150Z",
-			"updated_at": "2021-08-26T20:08:14.725Z",
-			"two_factor_auth_configured": false
-		}
-}`
-
-		_, err := w.Write([]byte(out))
-		c.Assert(err, qt.IsNil)
-	}))
-
-	client, err := NewClient(WithBaseURL(ts.URL))
-	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
-	org := "my-org"
-	name := "planetscale-go-test-db"
-
-	db, err := client.DatabaseBranches.GetPromotionRequest(ctx, &GetPromotionRequestRequest{
-		Organization: org,
-		Database:     name,
-		Branch:       "planetscale-go-test-db-branch",
-	})
-
-	want := &BranchPromotionRequest{
-		ID:         "test-promotion-branch",
-		State:      "promoted",
-		Branch:     "main",
-		CreatedAt:  testTime,
-		UpdatedAt:  testTime,
-		StartedAt:  &testTime,
-		FinishedAt: &testTime,
-	}
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(db, qt.DeepEquals, want)
-}
-
-func TestBranches_DemoteWithDemotionRequest(t *testing.T) {
-	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
-	c := qt.New(t)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodPost, qt.Equals, r.Method)
-		w.WriteHeader(200)
-		out := `
-	{
-	"id": "test-demotion-request",
-	"type": "BranchDemotionRequest",
-	"branch": "main",
-	"actor": {
-	"id": "test-actor",
-	"type": "User",
-	"display_name": "Test User",
-	"name": null,
-	"email": "test@example.com",
-	"avatar_url": "https://app.planetscale.com/gravatar-fallback.png",
-	"created_at": "2021-01-14T10:19:23.000Z",
-				"updated_at": "2021-01-14T10:19:23.000Z",
-	"two_factor_auth_configured": false
-	},
-	"responder": null,
-	"created_at": "2021-01-14T10:19:23.000Z",
-	"responded_at": null,
-	"state": "pending"
-	}
-`
-
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"planetscale-go-test-db-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z","production": false}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -451,144 +298,21 @@ func TestBranches_DemoteWithDemotionRequest(t *testing.T) {
 	name := "my-test-db"
 	branch := "main"
 
-	dr, err := client.DatabaseBranches.Demote(ctx, &DemoteRequest{
+	b, err := client.DatabaseBranches.Demote(ctx, &DemoteRequest{
 		Organization: org,
 		Database:     name,
 		Branch:       branch,
 	})
 
-	want := &BranchDemotionRequest{
-		ID:    "test-demotion-request",
-		State: "pending",
-		Actor: &Actor{
-			ID:   "test-actor",
-			Type: "User",
-			Name: "Test User",
-		},
-		CreatedAt:   testTime,
-		RespondedAt: nil,
-		Responder:   nil,
+	want := &DatabaseBranch{
+		Name:       testBranch,
+		Production: false,
+		CreatedAt:  time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt:  time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 	}
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(dr, qt.DeepEquals, want)
-}
-
-func TestBranches_DemoteNoDemotionRequest(t *testing.T) {
-	c := qt.New(t)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodPost, qt.Equals, r.Method)
-		w.WriteHeader(204)
-	}))
-
-	client, err := NewClient(WithBaseURL(ts.URL))
-	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
-	org := "my-org"
-	name := "my-test-db"
-	branch := "main"
-
-	dr, err := client.DatabaseBranches.Demote(ctx, &DemoteRequest{
-		Organization: org,
-		Database:     name,
-		Branch:       branch,
-	})
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(dr, qt.IsNil)
-}
-
-func TestBranches_GetDemotionRequest(t *testing.T) {
-	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
-
-	c := qt.New(t)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodGet, qt.Equals, r.Method)
-		w.WriteHeader(200)
-		out := `
-{
-	"id": "test-demotion-request",
-	"type": "BranchDemotionRequest",
-	"branch": "main",
-	"actor": {
-	"id": "test-actor",
-	"type": "User",
-	"display_name": "Test User",
-	"name": null,
-	"email": "test@example.com",
-	"avatar_url": "https://app.planetscale.com/gravatar-fallback.png",
-	"created_at": "2021-01-14T10:19:23.000Z",
-				"updated_at": "2021-01-14T10:19:23.000Z",
-	"two_factor_auth_configured": false
-	},
-	"responder": null,
-	"created_at": "2021-01-14T10:19:23.000Z",
-	"responded_at": null,
-	"state": "pending"
-	}
-`
-
-		_, err := w.Write([]byte(out))
-		c.Assert(err, qt.IsNil)
-	}))
-
-	client, err := NewClient(WithBaseURL(ts.URL))
-	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
-	org := "my-org"
-	name := "my-test-db"
-	branch := "main"
-
-	dr, err := client.DatabaseBranches.GetDemotionRequest(ctx, &GetDemotionRequestRequest{
-		Organization: org,
-		Database:     name,
-		Branch:       branch,
-	})
-
-	want := &BranchDemotionRequest{
-		ID:    "test-demotion-request",
-		State: "pending",
-		Actor: &Actor{
-			ID:   "test-actor",
-			Type: "User",
-			Name: "Test User",
-		},
-		CreatedAt:   testTime,
-		RespondedAt: nil,
-		Responder:   nil,
-	}
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(dr, qt.DeepEquals, want)
-}
-
-func TestBranches_DenyDemotionRequest(t *testing.T) {
-	c := qt.New(t)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(http.MethodDelete, qt.Equals, r.Method)
-		w.WriteHeader(204)
-	}))
-
-	client, err := NewClient(WithBaseURL(ts.URL))
-	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
-	org := "my-org"
-	name := "my-test-db"
-	branch := "main"
-
-	err = client.DatabaseBranches.DenyDemotionRequest(ctx, &DenyDemotionRequestRequest{
-		Organization: org,
-		Database:     name,
-		Branch:       branch,
-	})
-
-	c.Assert(err, qt.IsNil)
+	c.Assert(b, qt.DeepEquals, want)
 }
 
 func TestDatabaseBranches_Promote(t *testing.T) {


### PR DESCRIPTION
This pull request removes everything relating to `PromotionRequest` and `DemotionRequest`. This is because we transformed these into synchronous actions when we added safe migrations.