### PR TITLE
Service token resource can either be a Database or Organization

### DIFF
--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -71,7 +71,7 @@ func TestDo(t *testing.T) {
 			response: `
 { 
 	"id": "509",
-	"type": "database",
+	"type": "Database",
 	"name": "foo-bar",
 	"notes": ""
 }`,
@@ -81,6 +81,7 @@ func TestDo(t *testing.T) {
 			v: &Database{},
 			want: &Database{
 				Name: "foo-bar",
+				Type: "Database",
 			},
 		},
 		{

--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -90,6 +90,7 @@ const (
 type Database struct {
 	Name      string        `json:"name"`
 	Notes     string        `json:"notes"`
+	Type      string        `json:"type"`
 	Region    Region        `json:"region"`
 	State     DatabaseState `json:"state"`
 	HtmlURL   string        `json:"html_url"`

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -20,7 +20,7 @@ func TestDatabases_Create(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": { "slug": "us-west", "display_name": "US West" },"state":"ready"}`
+		out := `{"id":"planetscale-go-test-db","type":"Database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": { "slug": "us-west", "display_name": "US West" },"state":"ready"}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -44,6 +44,7 @@ func TestDatabases_Create(t *testing.T) {
 		Name:  name,
 		Notes: notes,
 		State: DatabaseReady,
+		Type:  "Database",
 		Region: Region{
 			Slug: "us-west",
 			Name: "US West",
@@ -61,7 +62,7 @@ func TestDatabases_Get(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		out := `{"id":"planetscale-go-test-db","type":"Database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -81,6 +82,7 @@ func TestDatabases_Get(t *testing.T) {
 
 	want := &Database{
 		Name:      name,
+		Type:      "Database",
 		Notes:     notes,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
@@ -95,7 +97,7 @@ func TestDatabases_List(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"data":[{"id":"planetscale-go-test-db","type":"database", "name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
+		out := `{"data":[{"id":"planetscale-go-test-db","type":"Database", "name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
@@ -115,6 +117,7 @@ func TestDatabases_List(t *testing.T) {
 	want := []*Database{{
 		Name:      name,
 		Notes:     notes,
+		Type:      "Database",
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 	}}
@@ -128,7 +131,7 @@ func TestDatabases_ListWithOptions(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		out := `{"data":[{"id":"planetscale-go-test-db","type":"database", "name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
+		out := `{"data":[{"id":"planetscale-go-test-db","type":"Database", "name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
@@ -150,6 +153,7 @@ func TestDatabases_ListWithOptions(t *testing.T) {
 	want := []*Database{{
 		Name:      name,
 		Notes:     notes,
+		Type:      "Database",
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 	}}

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -34,6 +34,7 @@ type ListOrganizationRegionsRequest struct {
 // Organization represents a PlanetScale organization.
 type Organization struct {
 	Name                   string    `json:"name"`
+	Type                   string    `json:"type"`
 	CreatedAt              time.Time `json:"created_at"`
 	UpdatedAt              time.Time `json:"updated_at"`
 	RemainingFreeDatabases int       `json:"free_databases_remaining"`

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -19,7 +19,7 @@ func TestOrganizations_List(t *testing.T) {
   "data": [
     {
       "id": "my-cool-org",
-      "type": "organization",
+      "type": "Organization",
 	  "name": "my-cool-org",
 	  "created_at": "2021-01-14T10:19:23.000Z",
 	  "updated_at": "2021-01-14T10:19:23.000Z"
@@ -42,6 +42,7 @@ func TestOrganizations_List(t *testing.T) {
 	want := []*Organization{
 		{
 			Name:      "my-cool-org",
+			Type:      "Organization",
 			CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 			UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		},
@@ -57,7 +58,7 @@ func TestOrganizations_Get(t *testing.T) {
 		w.WriteHeader(200)
 		out := `{
       "id": "my-cool-org",
-      "type": "organization",
+      "type": "Organization",
       "name": "my-cool-org",
       "created_at": "2021-01-14T10:19:23.000Z",
       "updated_at": "2021-01-14T10:19:23.000Z"
@@ -79,6 +80,7 @@ func TestOrganizations_Get(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	want := &Organization{
 		Name:      "my-cool-org",
+		Type:      "Organization",
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 	}

--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -172,10 +172,17 @@ type serviceTokensResponse struct {
 }
 
 type ServiceTokenAccess struct {
-	ID       string   `json:"id"`
-	Access   string   `json:"access"`
-	Type     string   `json:"type"`
-	Resource Database `json:"resource"`
+	ID       string                     `json:"id"`
+	Access   string                     `json:"access"`
+	Type     string                     `json:"type"`
+	Resource ServiceTokenAccessResource `json:"resource"`
+}
+
+func (d Database) isServiceTokenAccessResource()     {}
+func (o Organization) isServiceTokenAccessResource() {}
+
+type ServiceTokenAccessResource interface {
+	isServiceTokenAccessResource()
 }
 
 type serviceTokenAccessResponse struct {

--- a/planetscale/service_tokens_test.go
+++ b/planetscale/service_tokens_test.go
@@ -151,6 +151,7 @@ func TestServiceTokens_GetAccess(t *testing.T) {
 			Type:   "DatabaseAccess",
 			Resource: Database{
 				Name:      "hidden-river-4209",
+				Type:      "Database",
 				Notes:     "",
 				CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 				UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
@@ -196,6 +197,7 @@ func TestServiceTokens_AddAccess(t *testing.T) {
 			Type:   "DatabaseAccess",
 			Resource: Database{
 				Name:      "hidden-river-4209",
+				Type:      "Database",
 				Notes:     "",
 				CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 				UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),


### PR DESCRIPTION
I'm working on adding support to the CLI for adding organization level accesses.

When this was originally built, we only had database level accesses. All the code assumes a `Resource` is a database.

This allows a Resource to be either an `Organization` or a `Database`. + Custom Unmarshal function for handling.