### PR TITLE
Add Replica option to DatabaseBranchPassword

### DIFF
--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -36,6 +36,7 @@ type DatabaseBranchPassword struct {
 	ConnectionStrings ConnectionStrings `json:"connection_strings"`
 	TTL               int               `json:"ttl_seconds"`
 	Renewable         bool              `json:"renewable"`
+	Replica           bool              `json:"replica"`
 }
 
 // DatabaseBranchPasswordRequest encapsulates the request for creating/getting/deleting a

--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -47,6 +47,7 @@ type DatabaseBranchPasswordRequest struct {
 	Role         string `json:"role,omitempty"`
 	Name         string `json:"name"`
 	TTL          int    `json:"ttl,omitempty"`
+	Replica      bool   `json:"replica,omitempty"`
 }
 
 // ListDatabaseBranchPasswordRequest encapsulates the request for listing all passwords

--- a/planetscale/passwords_test.go
+++ b/planetscale/passwords_test.go
@@ -23,7 +23,8 @@ func TestPasswords_Create(t *testing.T) {
     "role": "admin",
     "plain_text": "%s",
     "name": "planetscale-go-test-password",
-    "created_at": "2021-01-14T10:19:23.000Z"
+    "created_at": "2021-01-14T10:19:23.000Z",
+		"replica": false
 }`, testPasswordID, plainText)
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
@@ -51,6 +52,7 @@ func TestPasswords_Create(t *testing.T) {
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		Role:      "admin",
 		PlainText: plainText,
+		Replica:   false,
 	}
 
 	c.Assert(err, qt.IsNil)
@@ -67,7 +69,8 @@ func TestPasswords_CreateReplica(t *testing.T) {
     "role": "reader",
     "plain_text": "%s",
     "name": "planetscale-go-test-replica-password",
-    "created_at": "2021-01-14T10:19:23.000Z"
+    "created_at": "2021-01-14T10:19:23.000Z",
+		"replica": true
 }`, testPasswordID, plainText)
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
@@ -96,6 +99,7 @@ func TestPasswords_CreateReplica(t *testing.T) {
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		Role:      "reader",
 		PlainText: plainText,
+		Replica:   true,
 	}
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
Adds a `Replica` to `DatabaseBranchPassword` and `DatabaseBranchPasswordRequest`. 