### PR TITLE
Add instant ddl types

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -157,6 +157,9 @@ type DeployRequest struct {
 
 	HtmlURL string `json:"html_url"`
 
+	InstantDDLEligible bool `json:"instant_ddl_eligible"`
+	InstantDDL         bool `json:"instant_ddl"`
+
 	CreatedAt  time.Time  `json:"created_at"`
 	UpdatedAt  time.Time  `json:"updated_at"`
 	ClosedAt   *time.Time `json:"closed_at"`

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -50,6 +50,7 @@ type PerformDeployRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Number       uint64 `json:"-"`
+	InstantDDL   bool   `json:"-"`
 }
 
 // GetDeployRequest encapsulates the request for getting a single deploy


### PR DESCRIPTION
Adds the two instant ddl fields:
- `instant_ddl`
- `instant_ddl_eligible`

to the `Deployment` struct. And also adds `InstantDDL` boolean to the `PerformDeployRequest` that deploys a DR instsantly.