### PR TITLE
Pass `instant_ddl` query param when present

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -293,6 +294,15 @@ func (d *deployRequestsService) CloseDeploy(ctx context.Context, closeReq *Close
 // Deploy approves and executes a specific deploy request.
 func (d *deployRequestsService) Deploy(ctx context.Context, deployReq *PerformDeployRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "deploy")
+
+	queryParams := url.Values{}
+	if deployReq.InstantDDL {
+		queryParams.Set("instant_ddl", strconv.FormatBool(deployReq.InstantDDL))
+	}
+	if len(queryParams) > 0 {
+		path += "?" + queryParams.Encode()
+	}
+
 	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating http request")

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -90,6 +90,50 @@ func TestDeployRequests_Deploy(t *testing.T) {
 	c.Assert(dr, qt.DeepEquals, want)
 }
 
+func TestDeployRequests_InstantDeploy(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Query(), qt.DeepEquals, url.Values{"instant_ddl": []string{"true"}})
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": "2021-01-14T10:19:23.000Z", "deployment": { "state": "queued", "instant_ddl": true }, "number": 1337}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	dr, err := client.DeployRequests.Deploy(ctx, &PerformDeployRequest{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+		InstantDDL:   true,
+	})
+
+	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
+
+	want := &DeployRequest{
+		ID:         "test-deploy-request-id",
+		Branch:     "development",
+		IntoBranch: "some-branch",
+		Number:     1337,
+		Deployment: &Deployment{
+			State:      "queued",
+			InstantDDL: true,
+		},
+		Notes:     "",
+		CreatedAt: testTime,
+		UpdatedAt: testTime,
+		ClosedAt:  &testTime,
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dr, qt.DeepEquals, want)
+}
+
 func TestDeployRequests_CancelDeploy(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
This PR modifies the `Deploy` path to pass the `instant_ddl` query param when it is present on `PerformDeployRequest`.