### PR TITLE
Just pass `instant_ddl` in request body

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -51,7 +50,7 @@ type PerformDeployRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Number       uint64 `json:"-"`
-	InstantDDL   bool   `json:"-"`
+	InstantDDL   bool   `json:"instant_ddl"`
 }
 
 // GetDeployRequest encapsulates the request for getting a single deploy
@@ -294,15 +293,6 @@ func (d *deployRequestsService) CloseDeploy(ctx context.Context, closeReq *Close
 // Deploy approves and executes a specific deploy request.
 func (d *deployRequestsService) Deploy(ctx context.Context, deployReq *PerformDeployRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(deployReq.Organization, deployReq.Database, deployReq.Number, "deploy")
-
-	queryParams := url.Values{}
-	if deployReq.InstantDDL {
-		queryParams.Set("instant_ddl", strconv.FormatBool(deployReq.InstantDDL))
-	}
-	if len(queryParams) > 0 {
-		path += "?" + queryParams.Encode()
-	}
-
 	req, err := d.client.newRequest(http.MethodPost, path, deployReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating http request")


### PR DESCRIPTION
Changes `Deploy` to just pass `instant_ddl` in the body, and updates the test to look for the body in the request.