### PR TITLE
Add `auto_delete_branch` and `auto_cutover` to DR creation

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -192,7 +192,7 @@ type CreateDeployRequestRequest struct {
 	Branch           string `json:"branch"`
 	IntoBranch       string `json:"into_branch,omitempty"`
 	Notes            string `json:"notes"`
-	AutoApply        bool   `json:"auto_apply,omitempty"`
+	AutoCutover      bool   `json:"auto_cutover,omitempty"`
 	AutoDeleteBranch bool   `json:"auto_delete_branch,omitempty"`
 }
 

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -192,6 +192,7 @@ type CreateDeployRequestRequest struct {
 	Branch           string `json:"branch"`
 	IntoBranch       string `json:"into_branch,omitempty"`
 	Notes            string `json:"notes"`
+	AutoApply        bool   `json:"auto_apply,omitempty"`
 	AutoDeleteBranch bool   `json:"auto_delete_branch,omitempty"`
 }
 

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -187,11 +187,12 @@ type CancelDeployRequestRequest struct {
 }
 
 type CreateDeployRequestRequest struct {
-	Organization string `json:"-"`
-	Database     string `json:"-"`
-	Branch       string `json:"branch"`
-	IntoBranch   string `json:"into_branch,omitempty"`
-	Notes        string `json:"notes"`
+	Organization     string `json:"-"`
+	Database         string `json:"-"`
+	Branch           string `json:"branch"`
+	IntoBranch       string `json:"into_branch,omitempty"`
+	Notes            string `json:"notes"`
+	AutoDeleteBranch bool   `json:"auto_delete_branch,omitempty"`
 }
 
 type SkipRevertDeployRequestRequest struct {

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -242,7 +242,7 @@ func TestDeployRequests_Create(t *testing.T) {
 		Database:         testDatabase,
 		Notes:            "",
 		AutoDeleteBranch: true,
-		AutoApply:        false,
+		AutoCutover:      false,
 	})
 
 	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -238,9 +238,11 @@ func TestDeployRequests_Create(t *testing.T) {
 	ctx := context.Background()
 
 	requests, err := client.DeployRequests.Create(ctx, &CreateDeployRequestRequest{
-		Organization: testOrg,
-		Database:     testDatabase,
-		Notes:        "",
+		Organization:     testOrg,
+		Database:         testDatabase,
+		Notes:            "",
+		AutoDeleteBranch: true,
+		AutoApply:        false,
 	})
 
 	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)


### PR DESCRIPTION
auto_delete_branch:
- Allows for the `from` branch to automatically be deleted once the DR is complete.

auto_cutover
- Whether or not to set the DR to auto cutover when ready.