### PR TITLE
Fix versioning for `planetscale-go` headers

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -133,8 +133,11 @@ func defaultUserAgent() string {
 	libraryVersion := "unknown"
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
-		if buildInfo.Main.Version != "" {
-			libraryVersion = buildInfo.Main.Version
+		for _, dep := range buildInfo.Deps {
+			if dep.Path == "github.com/planetscale/planetscale-go" {
+				libraryVersion = dep.Version
+				break
+			}
 		}
 	}
 

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 
 	"github.com/hashicorp/go-cleanhttp"
@@ -18,11 +19,6 @@ import (
 const (
 	DefaultBaseURL = "https://api.planetscale.com/"
 	jsonMediaType  = "application/json"
-)
-
-const (
-	libraryVersion = "v0.67.0"
-	userAgent      = "planetscale-go/" + libraryVersion
 )
 
 // ErrorCode defines the code of an error.
@@ -133,6 +129,18 @@ func WithPerPage(perPage int) ListOption {
 // ClientOption provides a variadic option for configuring the client
 type ClientOption func(c *Client) error
 
+func defaultUserAgent() string {
+	libraryVersion := "unknown"
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		if buildInfo.Main.Version != "" {
+			libraryVersion = buildInfo.Main.Version
+		}
+	}
+
+	return "planetscale-go/" + libraryVersion
+}
+
 // WithUserAgent overrides the User-Agent header.
 func WithUserAgent(userAgent string) ClientOption {
 	return func(c *Client) error {
@@ -223,7 +231,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		client:    cleanhttp.DefaultClient(),
 		baseURL:   baseURL,
-		UserAgent: userAgent,
+		UserAgent: defaultUserAgent(),
 		headers:   make(map[string]string, 0),
 	}
 

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -28,7 +28,7 @@ func TestDo(t *testing.T) {
 			response:   `{}`,
 			method:     http.MethodGet,
 			wantHeaders: map[string]string{
-				"User-Agent": "planetscale-go/v0.67.0",
+				"User-Agent": "planetscale-go/unknown",
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func TestDo(t *testing.T) {
 			clientOptions: []ClientOption{WithUserAgent("test-user-agent"), WithRequestHeaders(map[string]string{"Test-Header": "test-value"})},
 			wantHeaders: map[string]string{
 				"Test-Header": "test-value",
-				"User-Agent":  "test-user-agent planetscale-go/v0.67.0",
+				"User-Agent":  "test-user-agent planetscale-go/unknown",
 			},
 		},
 		{


### PR DESCRIPTION
This pull request changes our `planetscale-go` headers from being a static string to using the version from whatever the imported module is in the built binary. Otherwise, it will default to `planetscale-go/unknown`.