### PR TITLE
Use `extra_replicas` for creating a keyspace

### DIFF
--- a/planetscale/keyspaces.go
+++ b/planetscale/keyspaces.go
@@ -42,7 +42,7 @@ type CreateBranchKeyspaceRequest struct {
 	Branch        string      `json:"-"`
 	Name          string      `json:"name"`
 	ClusterSize   ClusterSize `json:"cluster_size"`
-	ExtraReplicas int         `json:"replicas"`
+	ExtraReplicas int         `json:"extra_replicas"`
 	Shards        int         `json:"shards"`
 }
 


### PR DESCRIPTION
To ease up confusion, we are changing to using `extra_replicas` instead of `replicas`. It's more explicit about what's going on.