### PR TITLE
client: only execute defaultUserAgent once

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"runtime/debug"
 	"strconv"
+	"sync"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/pkg/errors"
@@ -129,7 +130,7 @@ func WithPerPage(perPage int) ListOption {
 // ClientOption provides a variadic option for configuring the client
 type ClientOption func(c *Client) error
 
-func defaultUserAgent() string {
+var defaultUserAgent = sync.OnceValue(func() string {
 	libraryVersion := "unknown"
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
@@ -142,7 +143,7 @@ func defaultUserAgent() string {
 	}
 
 	return "planetscale-go/" + libraryVersion
-}
+})
 
 // WithUserAgent overrides the User-Agent header.
 func WithUserAgent(userAgent string) ClientOption {


### PR DESCRIPTION
Reading the build info quite expensive, and this wraps the call in a sync.Once so it's only executed the first time, and the result is memoized since the value never changes.