### PR TITLE
Add `ListClusterSizeSKUs` to organizations service

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -105,6 +105,14 @@ func WithLimit(limit int) ListOption {
 	}
 }
 
+// WithRates returns a ListOption that sets the "rates" URL parameter.
+func WithRates() ListOption {
+	return func(opt *ListOptions) error {
+		opt.URLValues.Set("rates", "true")
+		return nil
+	}
+}
+
 // WithPage returns a ListOption that sets the "page" URL parameter.
 func WithPage(page int) ListOption {
 	return func(opt *ListOptions) error {

--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -113,6 +113,16 @@ func WithRates() ListOption {
 	}
 }
 
+// WithRegion returns a ListOption sets the "region" URL parameter.
+func WithRegion(region string) ListOption {
+	return func(opt *ListOptions) error {
+		if len(region) > 0 {
+			opt.URLValues.Set("region", region)
+		}
+		return nil
+	}
+}
+
 // WithPage returns a ListOption that sets the "page" URL parameter.
 func WithPage(page int) ListOption {
 	return func(opt *ListOptions) error {

--- a/planetscale/client_test.go
+++ b/planetscale/client_test.go
@@ -162,3 +162,7 @@ func TestDo(t *testing.T) {
 		})
 	}
 }
+
+func Pointer[K any](val K) *K {
+	return &val
+}

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -53,6 +53,7 @@ type ClusterSKU struct {
 	Provider             *string `json:"provider"`
 	Enabled              bool    `json:"enabled"`
 	DefaultVTGate        string  `json:"default_vtgate"`
+	DefaultVTGateRate    *int64  `json:"default_vtgate_rate"`
 }
 
 // Organization represents a PlanetScale organization.

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -23,12 +23,36 @@ type OrganizationsService interface {
 	Get(context.Context, *GetOrganizationRequest) (*Organization, error)
 	List(context.Context) ([]*Organization, error)
 	ListRegions(context.Context, *ListOrganizationRegionsRequest) ([]*Region, error)
+	ListClusterSKUs(context.Context, *ListOrganizationClusterSKUsRequest, ...ListOption) ([]*ClusterSKU, error)
 }
 
 // ListRegionsRequest encapsulates the request for getting a list of regions for
 // an organization.
 type ListOrganizationRegionsRequest struct {
 	Organization string
+}
+
+// ListOrganizationClusterSKUsRequest encapsulates the request for getting a list of Cluster SKUs for an organization.
+type ListOrganizationClusterSKUsRequest struct {
+	Organization string
+	IncludeRates bool
+}
+
+// ClusterSKU represents a SKU for a PlanetScale cluster
+type ClusterSKU struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	CPU         string `json:"cpu"`
+	Memory      string `json:"ram"`
+
+	Storage *int64 `json:"storage,string"`
+
+	Rate                 *int64  `json:"rate"`
+	ReplicaRate          *int64  `json:"replica_rate"`
+	ProviderInstanceType *string `json:"provider_instance_type"`
+	Provider             *string `json:"provider"`
+	Enabled              bool    `json:"enabled"`
+	DefaultVTGate        string  `json:"default_vtgate"`
 }
 
 // Organization represents a PlanetScale organization.
@@ -101,4 +125,33 @@ func (o *organizationsService) ListRegions(ctx context.Context, listReq *ListOrg
 	}
 
 	return listResponse.Regions, nil
+}
+
+type listClusterSKUsResponse struct {
+	ClusterSKUs []*ClusterSKU `json:"data"`
+}
+
+func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *ListOrganizationClusterSKUsRequest, opts ...ListOption) ([]*ClusterSKU, error) {
+	path := fmt.Sprintf("%s/%s/cluster-size-skus", organizationsAPIPath, listReq.Organization)
+
+	defaultOpts := defaultListOptions()
+	for _, opt := range opts {
+		opt(defaultOpts)
+	}
+
+	if vals := defaultOpts.URLValues.Encode(); vals != "" {
+		path += "?" + vals
+	}
+
+	req, err := o.client.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating http request")
+	}
+
+	listResponse := &listClusterSKUsResponse{}
+	if err := o.client.do(ctx, req, &listResponse); err != nil {
+		return nil, err
+	}
+
+	return listResponse.ClusterSKUs, nil
 }


### PR DESCRIPTION
This pull request adds a `ListClusterSizeSKUs` to the organizations service. I thought about breaking this out into a `SizesService` so we could add in other sizes down the road, but figured we could cross that bridge when we get there, similar to what we did for regions and the `RegionsService`