### PR TITLE
Fix response payload for cluster SKUs

### DIFF
--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -128,10 +128,6 @@ func (o *organizationsService) ListRegions(ctx context.Context, listReq *ListOrg
 	return listResponse.Regions, nil
 }
 
-type listClusterSKUsResponse struct {
-	ClusterSKUs []*ClusterSKU `json:"data"`
-}
-
 func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *ListOrganizationClusterSKUsRequest, opts ...ListOption) ([]*ClusterSKU, error) {
 	path := fmt.Sprintf("%s/%s/cluster-size-skus", organizationsAPIPath, listReq.Organization)
 

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -149,10 +149,10 @@ func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *Lis
 		return nil, errors.Wrap(err, "error creating http request")
 	}
 
-	listResponse := &listClusterSKUsResponse{}
-	if err := o.client.do(ctx, req, &listResponse); err != nil {
+	clusterSKUs := []*ClusterSKU{}
+	if err := o.client.do(ctx, req, &clusterSKUs); err != nil {
 		return nil, err
 	}
 
-	return listResponse.ClusterSKUs, nil
+	return clusterSKUs, nil
 }

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -135,8 +135,7 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 		w.WriteHeader(200)
 
 		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-cool-org/cluster-size-skus")
-		out := `{
-"data": [
+		out := `[
 		{
 			"name": "PS_10",
 			"type": "ClusterSizeSku",
@@ -153,8 +152,7 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 			"default_vtgate": "VTG_5",
 			"default_vtgate_rate": null
 		}
-	]
-}`
+	]`
 
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
@@ -191,8 +189,7 @@ func TestOrganizations_ListClusterSKUsWithRates(t *testing.T) {
 		w.WriteHeader(200)
 
 		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-cool-org/cluster-size-skus?rates=true")
-		out := `{
-"data": [
+		out := `[
 		{
 			"name": "PS_10",
 			"type": "ClusterSizeSku",
@@ -209,8 +206,7 @@ func TestOrganizations_ListClusterSKUsWithRates(t *testing.T) {
 			"default_vtgate": "VTG_5",
 			"default_vtgate_rate": null
 		}
-	]
-}`
+	]`
 
 		_, err := w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)


### PR DESCRIPTION
This is not using a `data` key.