### PR TITLE
Add `IsDefault` to region

### DIFF
--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -45,6 +45,8 @@ type ClusterSKU struct {
 	CPU         string `json:"cpu"`
 	Memory      string `json:"ram"`
 
+	SortOrder int64 `json:"sort_order"`
+
 	Storage *int64 `json:"storage,string"`
 
 	Rate                 *int64  `json:"rate"`

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -150,7 +150,8 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 			"rate": null,
 			"replica_rate": null,
 			"default_vtgate": "VTG_5",
-			"default_vtgate_rate": null
+			"default_vtgate_rate": null,
+			"sort_order": 1
 		}
 	]`
 
@@ -176,6 +177,7 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 			Memory:        "1",
 			Enabled:       true,
 			DefaultVTGate: "VTG_5",
+			SortOrder:     1,
 		},
 	}
 

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -144,7 +144,6 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 			"provider_instance_type": null,
 			"storage": null,
 			"ram": "1",
-			"sort_order": 1,
 			"enabled": true,
 			"provider": null,
 			"rate": null,
@@ -235,6 +234,7 @@ func TestOrganizations_ListClusterSKUsWithRates(t *testing.T) {
 			Rate:          Pointer[int64](39),
 			ReplicaRate:   Pointer[int64](13),
 			DefaultVTGate: "VTG_5",
+			SortOrder:     1,
 		},
 	}
 

--- a/planetscale/regions.go
+++ b/planetscale/regions.go
@@ -10,11 +10,12 @@ import (
 const regionsAPIPath = "v1/regions"
 
 type Region struct {
-	Slug     string `json:"slug"`
-	Provider string `json:"provider"`
-	Name     string `json:"display_name"`
-	Location string `json:"location"`
-	Enabled  bool   `json:"enabled"`
+	Slug      string `json:"slug"`
+	Provider  string `json:"provider"`
+	Name      string `json:"display_name"`
+	Location  string `json:"location"`
+	Enabled   bool   `json:"enabled"`
+	IsDefault bool   `json:"current_default"`
 }
 
 type regionsResponse struct {

--- a/planetscale/regions_test.go
+++ b/planetscale/regions_test.go
@@ -23,7 +23,8 @@ func TestRegions_List(t *testing.T) {
 			"display_name": "US East",
 			"location": "Northern Virginia",
 			"provider": "AWS",
-			"enabled": true
+			"enabled": true,
+			"current_default": true
 		}
 	]
 }`
@@ -42,11 +43,12 @@ func TestRegions_List(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	want := []*Region{
 		{
-			Slug:     "us-east",
-			Provider: "AWS",
-			Name:     "US East",
-			Location: "Northern Virginia",
-			Enabled:  true,
+			Slug:      "us-east",
+			Provider:  "AWS",
+			Name:      "US East",
+			Location:  "Northern Virginia",
+			Enabled:   true,
+			IsDefault: true,
 		},
 	}
 


### PR DESCRIPTION
Our response payload for regions lets us know which is set to the be the default for an organization. Let's add that information here.