### PR TITLE
Add `ListClusterSizeSKUs` to branches

### DIFF
--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -35,7 +35,6 @@ type ListOrganizationRegionsRequest struct {
 // ListOrganizationClusterSKUsRequest encapsulates the request for getting a list of Cluster SKUs for an organization.
 type ListOrganizationClusterSKUsRequest struct {
 	Organization string
-	IncludeRates bool
 }
 
 // ClusterSKU represents a SKU for a PlanetScale cluster


### PR DESCRIPTION
This pull request is similar to #230 and let's us add the listing of cluster sizes to the database branches service. This will be helpful for listing valid sizes for creating a new keyspace.