### PR TITLE
Change type of storage to int64

### DIFF
--- a/planetscale/branches_test.go
+++ b/planetscale/branches_test.go
@@ -511,7 +511,7 @@ func TestDatabaseBranches_ListClusterSKUsWithRates(t *testing.T) {
 			"display_name": "PS-10",
 			"cpu": "1/8",
 			"provider_instance_type": null,
-			"storage": "100",
+			"storage": 100,
 			"ram": 1,
 			"sort_order": 1,
 			"enabled": true,

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -46,7 +46,7 @@ type ClusterSKU struct {
 
 	SortOrder int64 `json:"sort_order"`
 
-	Storage *int64 `json:"storage,string"`
+	Storage *int64 `json:"storage"`
 
 	Rate                 *int64  `json:"rate"`
 	ReplicaRate          *int64  `json:"replica_rate"`

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -197,7 +197,7 @@ func TestOrganizations_ListClusterSKUsWithRates(t *testing.T) {
 			"display_name": "PS-10",
 			"cpu": "1/8",
 			"provider_instance_type": null,
-			"storage": "100",
+			"storage": 100,
 			"ram": 1,
 			"sort_order": 1,
 			"enabled": true,


### PR DESCRIPTION
Similar to #237, we changed this type to be a number rather than a string. This fixes the marshaling for this attribute so it can be properly deserialized.