### PR TITLE
Update types for `Workflow`

### DIFF
--- a/planetscale/workflows.go
+++ b/planetscale/workflows.go
@@ -12,7 +12,7 @@ import (
 type Workflow struct {
 	ID                   string     `json:"id"`
 	Name                 string     `json:"name"`
-	Number               int        `json:"number"`
+	Number               uint64     `json:"number"`
 	State                string     `json:"state"`
 	CreatedAt            time.Time  `json:"created_at"`
 	UpdatedAt            time.Time  `json:"updated_at"`
@@ -80,9 +80,9 @@ type WorkflowTable struct {
 	Name           string    `json:"name"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
-	RowsCopied     int64     `json:"rows_copied"`
-	RowsTotal      int64     `json:"rows_total"`
-	RowsPercentage int       `json:"rows_percentage"`
+	RowsCopied     uint64    `json:"rows_copied"`
+	RowsTotal      uint64    `json:"rows_total"`
+	RowsPercentage uint      `json:"rows_percentage"`
 }
 
 type WorkflowVDiff struct {
@@ -93,8 +93,8 @@ type WorkflowVDiff struct {
 	StartedAt          *time.Time                 `json:"started_at"`
 	CompletedAt        *time.Time                 `json:"completed_at"`
 	HasMismatch        bool                       `json:"has_mismatch"`
-	ProgressPercentage int                        `json:"progress_percentage"`
-	EtaSeconds         int64                      `json:"eta_seconds"`
+	ProgressPercentage uint                       `json:"progress_percentage"`
+	EtaSeconds         uint64                     `json:"eta_seconds"`
 	TableReports       []WorkflowVDiffTableReport `json:"table_reports"`
 }
 
@@ -123,7 +123,7 @@ type ListWorkflowsRequest struct {
 type GetWorkflowRequest struct {
 	Organization   string `json:"-"`
 	Database       string `json:"-"`
-	WorkflowNumber int    `json:"-"`
+	WorkflowNumber uint64 `json:"-"`
 }
 
 // WorkflowsService is an interface for interacting with the workflow endpoints of the PlanetScale API
@@ -180,6 +180,6 @@ func workflowsAPIPath(org, db string) string {
 	return fmt.Sprintf("%s/%s/workflows", databasesAPIPath(org), db)
 }
 
-func workflowAPIPath(org, db string, number int) string {
+func workflowAPIPath(org, db string, number uint64) string {
 	return fmt.Sprintf("%s/%d", workflowsAPIPath(org, db), number)
 }

--- a/planetscale/workflows_test.go
+++ b/planetscale/workflows_test.go
@@ -35,7 +35,7 @@ func TestWorkflows_List(t *testing.T) {
 	c.Assert(len(workflows), qt.Equals, 1)
 	c.Assert(workflows[0].ID, qt.Equals, wantID)
 	c.Assert(workflows[0].Name, qt.Equals, "shard-table")
-	c.Assert(workflows[0].Number, qt.Equals, 1)
+	c.Assert(workflows[0].Number, qt.Equals, uint64(1))
 }
 
 func TestWorkflows_Get(t *testing.T) {
@@ -64,7 +64,7 @@ func TestWorkflows_Get(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(workflow.ID, qt.Equals, wantID)
 	c.Assert(workflow.Name, qt.Equals, "shard-table")
-	c.Assert(workflow.Number, qt.Equals, 1)
+	c.Assert(workflow.Number, qt.Equals, uint64(1))
 	c.Assert(workflow.SourceKeyspace.Name, qt.Equals, "source-keyspace")
 	c.Assert(workflow.TargetKeyspace.Name, qt.Equals, "target-keyspace")
 	c.Assert(workflow.Branch.Name, qt.Equals, "branch")


### PR DESCRIPTION
I realized when using this, we have a lot of `int` here. We should actually be using `uint` and `uint64` where possible, so this updates the types to accurately reflect that. 