### PR TITLE
Add cluster size to branch creation

### DIFF
--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -44,6 +44,7 @@ type CreateDatabaseBranchRequest struct {
 	ParentBranch string `json:"parent_branch"`
 	BackupID     string `json:"backup_id,omitempty"`
 	SeedData     string `json:"seed_data,omitempty"`
+	ClusterSize  string `json:"cluster_size,omitempty"`
 }
 
 // ListDatabaseBranchesRequest encapsulates the request for listing the branches


### PR DESCRIPTION
This pull request adds the `ClusterSize` attribute to the `CreateDatabaseBranchRequest`. This can only be used when restoring from a backup or when seeding data.