### PR TITLE
Add `Kind` field to `Database` struct

### DIFF
--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -69,6 +69,7 @@ type Database struct {
 	Notes     string        `json:"notes"`
 	Region    Region        `json:"region"`
 	State     DatabaseState `json:"state"`
+	Kind      string        `json:"kind"`
 	HtmlURL   string        `json:"html_url"`
 	CreatedAt time.Time     `json:"created_at"`
 	UpdatedAt time.Time     `json:"updated_at"`


### PR DESCRIPTION
The PlanetScale API now returns a `"kind": "mysql"` or `"kind": "postgresql"` field in database responses to API requests like `/v1/organizations/{organization}/databases`.

We should expose that to clients, which might need to know whether they're talking to MySQL or Postges.  So it goes in the `Database` struct.