### PR TITLE
Allow database to be created with `Kind`

### DIFF
--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -14,7 +14,7 @@ type CreateDatabaseRequest struct {
 	Notes        string `json:"notes,omitempty"`
 	Region       string `json:"region,omitempty"`
 	ClusterSize  string `json:"cluster_size"`
-	Kind         string `json:"kind,omitempty"` // e.g., "mysql" or "postgresql"
+	Kind         string `json:"kind,omitempty"`
 }
 
 // DatabaseRequest encapsulates the request for getting a single database.

--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -14,6 +14,7 @@ type CreateDatabaseRequest struct {
 	Notes        string `json:"notes,omitempty"`
 	Region       string `json:"region,omitempty"`
 	ClusterSize  string `json:"cluster_size"`
+	Kind         string `json:"kind,omitempty"` // e.g., "mysql" or "postgresql"
 }
 
 // DatabaseRequest encapsulates the request for getting a single database.

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,8 +62,13 @@ func TestDatabases_CreatePostgres(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["kind"], qt.Equals, "postgresql")
+
 		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": { "slug": "us-west", "display_name": "US West" },"state":"ready","kind":"postgresql"}`
-		_, err := w.Write([]byte(out))
+		_, err = w.Write([]byte(out))
 		c.Assert(err, qt.IsNil)
 	}))
 
@@ -79,7 +85,7 @@ func TestDatabases_CreatePostgres(t *testing.T) {
 		Region:       "us-west",
 		Name:         name,
 		Notes:        notes,
-		Kind:         "postgressql",
+		Kind:         "postgresql",
 	})
 
 	want := &Database{

--- a/planetscale/databases_test.go
+++ b/planetscale/databases_test.go
@@ -56,6 +56,49 @@ func TestDatabases_Create(t *testing.T) {
 	c.Assert(db, qt.DeepEquals, want)
 }
 
+func TestDatabases_CreatePostgres(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-db","type":"database","name":"planetscale-go-test-db","notes":"This is a test DB created from the planetscale-go API library","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": { "slug": "us-west", "display_name": "US West" },"state":"ready","kind":"postgresql"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	name := "planetscale-go-test-db"
+	notes := "This is a test DB created from the planetscale-go API library"
+
+	db, err := client.Databases.Create(ctx, &CreateDatabaseRequest{
+		Organization: org,
+		Region:       "us-west",
+		Name:         name,
+		Notes:        notes,
+		Kind:         "postgressql",
+	})
+
+	want := &Database{
+		Name:  name,
+		Notes: notes,
+		State: DatabaseReady,
+		Region: Region{
+			Slug: "us-west",
+			Name: "US West",
+		},
+		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		Kind:      "postgresql",
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.DeepEquals, want)
+}
+
 func TestDatabases_Get(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
This pull request adds the `Kind` to the database creation flow, so that way we can utilize that for creating Postgres databases.