### PR TITLE
Refactor path and query parameter handling

### DIFF
--- a/planetscale/audit_logs.go
+++ b/planetscale/audit_logs.go
@@ -125,11 +125,7 @@ func (o *auditlogsService) List(ctx context.Context, listReq *ListAuditLogsReque
 		}
 	}
 
-	if vals := defaultOpts.URLValues.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := o.client.newRequest(http.MethodGet, path, nil)
+	req, err := o.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for listing audit logs: %w", err)
 	}

--- a/planetscale/audit_logs.go
+++ b/planetscale/audit_logs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -142,5 +143,5 @@ func (o *auditlogsService) List(ctx context.Context, listReq *ListAuditLogsReque
 }
 
 func auditlogsAPIPath(org string) string {
-	return fmt.Sprintf("%s/%s/audit-log", organizationsAPIPath, org)
+	return path.Join(organizationsAPIPath, org, "audit-log")
 }

--- a/planetscale/backups.go
+++ b/planetscale/backups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -131,9 +132,9 @@ func (d *backupsService) Delete(ctx context.Context, deleteReq *DeleteBackupRequ
 }
 
 func backupsAPIPath(org, db, branch string) string {
-	return fmt.Sprintf("%s/backups", databaseBranchAPIPath(org, db, branch))
+	return path.Join(databaseBranchAPIPath(org, db, branch), "backups")
 }
 
 func backupAPIPath(org, db, branch, backup string) string {
-	return fmt.Sprintf("%s/%s", backupsAPIPath(org, db, branch), backup)
+	return path.Join(backupsAPIPath(org, db, branch), backup)
 }

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -221,7 +221,7 @@ type schemaResponse struct {
 }
 
 func (d *databaseBranchesService) Schema(ctx context.Context, schemaReq *BranchSchemaRequest) ([]*Diff, error) {
-	path := fmt.Sprintf("%s/schema", databaseBranchAPIPath(schemaReq.Organization, schemaReq.Database, schemaReq.Branch))
+	path := path.Join(databaseBranchAPIPath(schemaReq.Organization, schemaReq.Database, schemaReq.Branch), "schema")
 	v := url.Values{}
 	if schemaReq.Keyspace != "" {
 		v.Add("keyspace", schemaReq.Keyspace)

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -200,7 +201,7 @@ func NewDatabaseBranchesService(client *Client) *databaseBranchesService {
 }
 
 func (d *databaseBranchesService) Diff(ctx context.Context, diffReq *DiffBranchRequest) ([]*Diff, error) {
-	path := fmt.Sprintf("%s/diff", databaseBranchAPIPath(diffReq.Organization, diffReq.Database, diffReq.Branch))
+	path := path.Join(databaseBranchAPIPath(diffReq.Organization, diffReq.Database, diffReq.Branch), "diff")
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -244,7 +245,7 @@ func (d *databaseBranchesService) Schema(ctx context.Context, schemaReq *BranchS
 }
 
 func (d *databaseBranchesService) RoutingRules(ctx context.Context, routingRulesReq *BranchRoutingRulesRequest) (*RoutingRules, error) {
-	path := fmt.Sprintf("%s/routing-rules", databaseBranchAPIPath(routingRulesReq.Organization, routingRulesReq.Database, routingRulesReq.Branch))
+	path := path.Join(databaseBranchAPIPath(routingRulesReq.Organization, routingRulesReq.Database, routingRulesReq.Branch), "routing-rules")
 
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
@@ -260,7 +261,7 @@ func (d *databaseBranchesService) RoutingRules(ctx context.Context, routingRules
 }
 
 func (d *databaseBranchesService) UpdateRoutingRules(ctx context.Context, updateRoutingRulesReq *UpdateBranchRoutingRulesRequest) (*RoutingRules, error) {
-	path := fmt.Sprintf("%s/routing-rules", databaseBranchAPIPath(updateRoutingRulesReq.Organization, updateRoutingRulesReq.Database, updateRoutingRulesReq.Branch))
+	path := path.Join(databaseBranchAPIPath(updateRoutingRulesReq.Organization, updateRoutingRulesReq.Database, updateRoutingRulesReq.Branch), "routing-rules")
 
 	req, err := d.client.newRequest(http.MethodPatch, path, updateRoutingRulesReq)
 	if err != nil {
@@ -294,7 +295,7 @@ func (d *databaseBranchesService) Create(ctx context.Context, createReq *CreateD
 
 // Get returns a database branch for an organization's database.
 func (d *databaseBranchesService) Get(ctx context.Context, getReq *GetDatabaseBranchRequest) (*DatabaseBranch, error) {
-	path := fmt.Sprintf("%s/%s", databaseBranchesAPIPath(getReq.Organization, getReq.Database), getReq.Branch)
+	path := path.Join(databaseBranchesAPIPath(getReq.Organization, getReq.Database), getReq.Branch)
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -326,7 +327,7 @@ func (d *databaseBranchesService) List(ctx context.Context, listReq *ListDatabas
 
 // Delete deletes a database branch from an organization's database.
 func (d *databaseBranchesService) Delete(ctx context.Context, deleteReq *DeleteDatabaseBranchRequest) error {
-	path := fmt.Sprintf("%s/%s", databaseBranchesAPIPath(deleteReq.Organization, deleteReq.Database), deleteReq.Branch)
+	path := path.Join(databaseBranchesAPIPath(deleteReq.Organization, deleteReq.Database), deleteReq.Branch)
 	req, err := d.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("error creating request for delete branch: %w", err)
@@ -338,7 +339,7 @@ func (d *databaseBranchesService) Delete(ctx context.Context, deleteReq *DeleteD
 
 // RefreshSchema refreshes the schema for a
 func (d *databaseBranchesService) RefreshSchema(ctx context.Context, refreshReq *RefreshSchemaRequest) error {
-	path := fmt.Sprintf("%s/%s/refresh-schema", databaseBranchesAPIPath(refreshReq.Organization, refreshReq.Database), refreshReq.Branch)
+	path := path.Join(databaseBranchesAPIPath(refreshReq.Organization, refreshReq.Database), refreshReq.Branch, "refresh-schema")
 	req, err := d.client.newRequest(http.MethodPost, path, nil)
 	if err != nil {
 		return fmt.Errorf("error creating http request: %w", err)
@@ -353,7 +354,7 @@ func (d *databaseBranchesService) RefreshSchema(ctx context.Context, refreshReq 
 
 // Promote promotes a branch from development to production.
 func (d *databaseBranchesService) Promote(ctx context.Context, promoteReq *PromoteRequest) (*DatabaseBranch, error) {
-	path := fmt.Sprintf("%s/promote", databaseBranchAPIPath(promoteReq.Organization, promoteReq.Database, promoteReq.Branch))
+	path := path.Join(databaseBranchAPIPath(promoteReq.Organization, promoteReq.Database, promoteReq.Branch), "promote")
 	req, err := d.client.newRequest(http.MethodPost, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for branch promotion: %w", err)
@@ -371,7 +372,7 @@ func (d *databaseBranchesService) Promote(ctx context.Context, promoteReq *Promo
 // EnableSafeMigrations enables safe migrations for a production branch. This
 // will prevent DDL statements from being performed on the branch.
 func (d *databaseBranchesService) EnableSafeMigrations(ctx context.Context, enableReq *EnableSafeMigrationsRequest) (*DatabaseBranch, error) {
-	path := fmt.Sprintf("%s/safe-migrations", databaseBranchAPIPath(enableReq.Organization, enableReq.Database, enableReq.Branch))
+	path := path.Join(databaseBranchAPIPath(enableReq.Organization, enableReq.Database, enableReq.Branch), "safe-migrations")
 	req, err := d.client.newRequest(http.MethodPost, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for enabling safe migrations: %w", err)
@@ -389,7 +390,7 @@ func (d *databaseBranchesService) EnableSafeMigrations(ctx context.Context, enab
 // DisableSafeMigrations disables safe migrations for a production branch. This
 // will allow DDL statements to be performed on the branch.
 func (d *databaseBranchesService) DisableSafeMigrations(ctx context.Context, disableReq *DisableSafeMigrationsRequest) (*DatabaseBranch, error) {
-	path := fmt.Sprintf("%s/safe-migrations", databaseBranchAPIPath(disableReq.Organization, disableReq.Database, disableReq.Branch))
+	path := path.Join(databaseBranchAPIPath(disableReq.Organization, disableReq.Database, disableReq.Branch), "safe-migrations")
 	req, err := d.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for disabling safe migrations: %w", err)
@@ -408,7 +409,7 @@ func (d *databaseBranchesService) DisableSafeMigrations(ctx context.Context, dis
 // to an Enterprise organization, it will return a demote request and require a
 // second call by a different admin in order to complete demotion.
 func (d *databaseBranchesService) Demote(ctx context.Context, demoteReq *DemoteRequest) (*DatabaseBranch, error) {
-	path := fmt.Sprintf("%s/demote", databaseBranchAPIPath(demoteReq.Organization, demoteReq.Database, demoteReq.Branch))
+	path := path.Join(databaseBranchAPIPath(demoteReq.Organization, demoteReq.Database, demoteReq.Branch), "demote")
 	req, err := d.client.newRequest(http.MethodPost, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for branch demotion: %w", err)
@@ -431,7 +432,7 @@ type lintSchemaResponse struct {
 // LintSchema lints the current schema of a branch and returns any errors that
 // may be present.
 func (d *databaseBranchesService) LintSchema(ctx context.Context, lintReq *LintSchemaRequest) ([]*SchemaLintError, error) {
-	path := fmt.Sprintf("%s/schema/lint", databaseBranchAPIPath(lintReq.Organization, lintReq.Database, lintReq.Branch))
+	path := path.Join(databaseBranchAPIPath(lintReq.Organization, lintReq.Database, lintReq.Branch), "schema", "lint")
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for linting branch schema: %w", err)
@@ -447,7 +448,7 @@ func (d *databaseBranchesService) LintSchema(ctx context.Context, lintReq *LintS
 }
 
 func (o *databaseBranchesService) ListClusterSKUs(ctx context.Context, listReq *ListBranchClusterSKUsRequest, opts ...ListOption) ([]*ClusterSKU, error) {
-	path := fmt.Sprintf("%s/cluster-size-skus", databaseBranchAPIPath(listReq.Organization, listReq.Database, listReq.Branch))
+	path := path.Join(databaseBranchAPIPath(listReq.Organization, listReq.Database, listReq.Branch), "cluster-size-skus")
 
 	defaultOpts := defaultListOptions()
 	for _, opt := range opts {
@@ -475,9 +476,9 @@ func (o *databaseBranchesService) ListClusterSKUs(ctx context.Context, listReq *
 }
 
 func databaseBranchesAPIPath(org, db string) string {
-	return fmt.Sprintf("%s/%s/branches", databasesAPIPath(org), db)
+	return path.Join(databasesAPIPath(org), db, "branches")
 }
 
 func databaseBranchAPIPath(org, db, branch string) string {
-	return fmt.Sprintf("%s/%s", databaseBranchesAPIPath(org, db), branch)
+	return path.Join(databaseBranchesAPIPath(org, db), branch)
 }

--- a/planetscale/branches.go
+++ b/planetscale/branches.go
@@ -227,11 +227,7 @@ func (d *databaseBranchesService) Schema(ctx context.Context, schemaReq *BranchS
 		v.Add("keyspace", schemaReq.Keyspace)
 	}
 
-	if vals := v.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := d.client.newRequest(http.MethodGet, path, nil)
+	req, err := d.client.newRequest(http.MethodGet, path, nil, WithQueryParams(v))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -458,11 +454,7 @@ func (o *databaseBranchesService) ListClusterSKUs(ctx context.Context, listReq *
 		}
 	}
 
-	if vals := defaultOpts.URLValues.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := o.client.newRequest(http.MethodGet, path, nil)
+	req, err := o.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -105,11 +105,7 @@ func (ds *databasesService) List(ctx context.Context, listReq *ListDatabasesRequ
 		}
 	}
 
-	if vals := defaultOpts.URLValues.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := ds.client.newRequest(http.MethodGet, path, nil)
+	req, err := ds.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -138,7 +139,7 @@ func (ds *databasesService) Create(ctx context.Context, createReq *CreateDatabas
 }
 
 func (ds *databasesService) Get(ctx context.Context, getReq *GetDatabaseRequest) (*Database, error) {
-	path := fmt.Sprintf("%s/%s", databasesAPIPath(getReq.Organization), getReq.Database)
+	path := path.Join(databasesAPIPath(getReq.Organization), getReq.Database)
 	req, err := ds.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for get database: %w", err)
@@ -154,7 +155,7 @@ func (ds *databasesService) Get(ctx context.Context, getReq *GetDatabaseRequest)
 }
 
 func (ds *databasesService) Delete(ctx context.Context, deleteReq *DeleteDatabaseRequest) (*DatabaseDeletionRequest, error) {
-	path := fmt.Sprintf("%s/%s", databasesAPIPath(deleteReq.Organization), deleteReq.Database)
+	path := path.Join(databasesAPIPath(deleteReq.Organization), deleteReq.Database)
 	req, err := ds.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for delete database: %w", err)
@@ -170,5 +171,5 @@ func (ds *databasesService) Delete(ctx context.Context, deleteReq *DeleteDatabas
 }
 
 func databasesAPIPath(org string) string {
-	return fmt.Sprintf("v1/organizations/%s/databases", org)
+	return path.Join("v1/organizations", org, "databases")
 }

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -531,14 +532,14 @@ func (d *deployRequestsService) GetDeployOperations(ctx context.Context, getReq 
 }
 
 func deployRequestsAPIPath(org, db string) string {
-	return fmt.Sprintf("%s/%s/deploy-requests", databasesAPIPath(org), db)
+	return path.Join(databasesAPIPath(org), db, "deploy-requests")
 }
 
 // deployRequestAPIPath gets the base path for accessing a single deploy request
 func deployRequestAPIPath(org string, db string, number uint64) string {
-	return fmt.Sprintf("%s/%s/deploy-requests/%d", databasesAPIPath(org), db, number)
+	return path.Join(databasesAPIPath(org), db, "deploy-requests", fmt.Sprintf("%d", number))
 }
 
-func deployRequestActionAPIPath(org string, db string, number uint64, path string) string {
-	return fmt.Sprintf("%s/%s", deployRequestAPIPath(org, db, number), path)
+func deployRequestActionAPIPath(org string, db string, number uint64, actionPath string) string {
+	return path.Join(deployRequestAPIPath(org, db, number), actionPath)
 }

--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -468,11 +468,7 @@ func (d *deployRequestsService) List(ctx context.Context, listReq *ListDeployReq
 		queryParams.Set("into_branch", listReq.IntoBranch)
 	}
 
-	if len(queryParams) > 0 {
-		baseURL += "?" + queryParams.Encode()
-	}
-
-	req, err := d.client.newRequest(http.MethodGet, baseURL, nil)
+	req, err := d.client.newRequest(http.MethodGet, baseURL, nil, WithQueryParams(queryParams))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/imports.go
+++ b/planetscale/imports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -243,8 +244,8 @@ type dataImportsService struct {
 // TestDataImportSource will check an external database for compatibility with PlanetScale
 func (d *dataImportsService) TestDataImportSource(ctx context.Context, request *TestDataImportSourceRequest) (*TestDataImportSourceResponse, error) {
 	request.Connection.SSLMode = request.Connection.SSLVerificationMode.String()
-	path := fmt.Sprintf("/v1/organizations/%s/data-imports/test-connection", request.Organization)
-	req, err := d.client.newRequest(http.MethodPost, path, request)
+	pathStr := path.Join("/v1/organizations", request.Organization, "data-imports/test-connection")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, request)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -264,8 +265,8 @@ func (d *dataImportsService) TestDataImportSource(ctx context.Context, request *
 
 func (d *dataImportsService) StartDataImport(ctx context.Context, request *StartDataImportRequest) (*DataImport, error) {
 	request.Connection.SSLMode = request.Connection.SSLVerificationMode.String()
-	path := fmt.Sprintf("/v1/organizations/%s/data-imports/new", request.Organization)
-	req, err := d.client.newRequest(http.MethodPost, path, request)
+	pathStr := path.Join("/v1/organizations", request.Organization, "data-imports/new")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, request)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -279,8 +280,8 @@ func (d *dataImportsService) StartDataImport(ctx context.Context, request *Start
 }
 
 func (d *dataImportsService) GetDataImportStatus(ctx context.Context, getReq *GetImportStatusRequest) (*DataImport, error) {
-	path := dataImportAPIPath(getReq.Organization, getReq.Database)
-	req, err := d.client.newRequest(http.MethodGet, path, nil)
+	pathStr := dataImportAPIPath(getReq.Organization, getReq.Database)
+	req, err := d.client.newRequest(http.MethodGet, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for get database: %w", err)
 	}
@@ -296,8 +297,8 @@ func (d *dataImportsService) GetDataImportStatus(ctx context.Context, getReq *Ge
 }
 
 func (d *dataImportsService) CancelDataImport(ctx context.Context, cancelReq *CancelDataImportRequest) error {
-	path := fmt.Sprintf("%s/cancel", dataImportAPIPath(cancelReq.Organization, cancelReq.Database))
-	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	pathStr := path.Join(dataImportAPIPath(cancelReq.Organization, cancelReq.Database), "cancel")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, nil)
 	if err != nil {
 		return fmt.Errorf("error creating http request: %w", err)
 	}
@@ -310,8 +311,8 @@ func (d *dataImportsService) CancelDataImport(ctx context.Context, cancelReq *Ca
 }
 
 func (d *dataImportsService) MakePlanetScalePrimary(ctx context.Context, request *MakePlanetScalePrimaryRequest) (*DataImport, error) {
-	path := fmt.Sprintf("%s/begin-switch-traffic", dataImportAPIPath(request.Organization, request.Database))
-	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	pathStr := path.Join(dataImportAPIPath(request.Organization, request.Database), "begin-switch-traffic")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -325,8 +326,8 @@ func (d *dataImportsService) MakePlanetScalePrimary(ctx context.Context, request
 }
 
 func (d *dataImportsService) MakePlanetScaleReplica(ctx context.Context, request *MakePlanetScaleReplicaRequest) (*DataImport, error) {
-	path := fmt.Sprintf("%s/begin-reverse-traffic", dataImportAPIPath(request.Organization, request.Database))
-	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	pathStr := path.Join(dataImportAPIPath(request.Organization, request.Database), "begin-reverse-traffic")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -340,8 +341,8 @@ func (d *dataImportsService) MakePlanetScaleReplica(ctx context.Context, request
 }
 
 func (d *dataImportsService) DetachExternalDatabase(ctx context.Context, request *DetachExternalDatabaseRequest) (*DataImport, error) {
-	path := fmt.Sprintf("%s/detach-external-database", dataImportAPIPath(request.Organization, request.Database))
-	req, err := d.client.newRequest(http.MethodPost, path, nil)
+	pathStr := path.Join(dataImportAPIPath(request.Organization, request.Database), "detach-external-database")
+	req, err := d.client.newRequest(http.MethodPost, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -356,5 +357,5 @@ func (d *dataImportsService) DetachExternalDatabase(ctx context.Context, request
 }
 
 func dataImportAPIPath(organization, database string) string {
-	return fmt.Sprintf("/v1/organizations/%s/databases/%s/data-imports", organization, database)
+	return path.Join("/v1/organizations", organization, "databases", database, "data-imports")
 }

--- a/planetscale/keyspaces.go
+++ b/planetscale/keyspaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -225,8 +226,8 @@ func (s *keyspacesService) Create(ctx context.Context, createReq *CreateKeyspace
 
 // VSchema returns the VSchema for a keyspace in a branch
 func (s *keyspacesService) VSchema(ctx context.Context, getReq *GetKeyspaceVSchemaRequest) (*VSchema, error) {
-	path := fmt.Sprintf("%s/vschema", keyspaceAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.Keyspace))
-	req, err := s.client.newRequest(http.MethodGet, path, nil)
+	pathStr := path.Join(keyspaceAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.Keyspace), "vschema")
+	req, err := s.client.newRequest(http.MethodGet, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -240,8 +241,8 @@ func (s *keyspacesService) VSchema(ctx context.Context, getReq *GetKeyspaceVSche
 }
 
 func (s *keyspacesService) UpdateVSchema(ctx context.Context, updateReq *UpdateKeyspaceVSchemaRequest) (*VSchema, error) {
-	path := fmt.Sprintf("%s/vschema", keyspaceAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch, updateReq.Keyspace))
-	req, err := s.client.newRequest(http.MethodPatch, path, updateReq)
+	pathStr := path.Join(keyspaceAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch, updateReq.Keyspace), "vschema")
+	req, err := s.client.newRequest(http.MethodPatch, pathStr, updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -280,15 +281,15 @@ func (s *keyspacesService) CancelResize(ctx context.Context, cancelReq *CancelKe
 }
 
 func keyspacesAPIPath(org, db, branch string) string {
-	return fmt.Sprintf("%s/keyspaces", databaseBranchAPIPath(org, db, branch))
+	return path.Join(databaseBranchAPIPath(org, db, branch), "keyspaces")
 }
 
 func keyspaceAPIPath(org, db, branch, keyspace string) string {
-	return fmt.Sprintf("%s/%s", keyspacesAPIPath(org, db, branch), keyspace)
+	return path.Join(keyspacesAPIPath(org, db, branch), keyspace)
 }
 
 func keyspaceResizesAPIPath(org, db, branch, keyspace string) string {
-	return fmt.Sprintf("%s/resizes", keyspaceAPIPath(org, db, branch, keyspace))
+	return path.Join(keyspaceAPIPath(org, db, branch, keyspace), "resizes")
 }
 
 type keyspaceResizesResponse struct {
@@ -318,7 +319,7 @@ func (s *keyspacesService) ResizeStatus(ctx context.Context, resizeReq *Keyspace
 }
 
 func keyspaceRolloutStatusAPIPath(org, db, branch, keyspace string) string {
-	return fmt.Sprintf("%s/rollout-status", keyspaceAPIPath(org, db, branch, keyspace))
+	return path.Join(keyspaceAPIPath(org, db, branch, keyspace), "rollout-status")
 }
 
 func (s *keyspacesService) RolloutStatus(ctx context.Context, rolloutReq *KeyspaceRolloutStatusRequest) (*KeyspaceRollout, error) {

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -83,7 +84,7 @@ func NewOrganizationsService(client *Client) *organizationsService {
 
 // Get fetches a single organization by name.
 func (o *organizationsService) Get(ctx context.Context, getReq *GetOrganizationRequest) (*Organization, error) {
-	req, err := o.client.newRequest(http.MethodGet, fmt.Sprintf("%s/%s", organizationsAPIPath, getReq.Organization), nil)
+	req, err := o.client.newRequest(http.MethodGet, path.Join(organizationsAPIPath, getReq.Organization), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for get organization: %w", err)
 	}
@@ -116,7 +117,7 @@ type listRegionsResponse struct {
 }
 
 func (o *organizationsService) ListRegions(ctx context.Context, listReq *ListOrganizationRegionsRequest) ([]*Region, error) {
-	req, err := o.client.newRequest(http.MethodGet, fmt.Sprintf("%s/%s/regions", organizationsAPIPath, listReq.Organization), nil)
+	req, err := o.client.newRequest(http.MethodGet, path.Join(organizationsAPIPath, listReq.Organization, "regions"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ func (o *organizationsService) ListRegions(ctx context.Context, listReq *ListOrg
 }
 
 func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *ListOrganizationClusterSKUsRequest, opts ...ListOption) ([]*ClusterSKU, error) {
-	path := fmt.Sprintf("%s/%s/cluster-size-skus", organizationsAPIPath, listReq.Organization)
+	path := path.Join(organizationsAPIPath, listReq.Organization, "cluster-size-skus")
 
 	defaultOpts := defaultListOptions()
 	for _, opt := range opts {

--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -141,11 +141,7 @@ func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *Lis
 		}
 	}
 
-	if vals := defaultOpts.URLValues.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := o.client.newRequest(http.MethodGet, path, nil)
+	req, err := o.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/passwords.go
+++ b/planetscale/passwords.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -192,17 +193,17 @@ func (d *passwordsService) Renew(ctx context.Context, renewReq *RenewDatabaseBra
 }
 
 func passwordBranchAPIPath(org, db, branch, password string) string {
-	return fmt.Sprintf("%s/%s", passwordsBranchAPIPath(org, db, branch), password)
+	return path.Join(passwordsBranchAPIPath(org, db, branch), password)
 }
 
 func passwordsBranchAPIPath(org, db, branch string) string {
-	return fmt.Sprintf("%s/passwords", databaseBranchAPIPath(org, db, branch))
+	return path.Join(databaseBranchAPIPath(org, db, branch), "passwords")
 }
 
 func passwordsAPIPath(org, db string) string {
-	return fmt.Sprintf("%s/%s/passwords", databasesAPIPath(org), db)
+	return path.Join(databasesAPIPath(org), db, "passwords")
 }
 
 func passwordRenewAPIPath(org, db, branch, password string) string {
-	return fmt.Sprintf("%s/renew", passwordBranchAPIPath(org, db, branch, password))
+	return path.Join(passwordBranchAPIPath(org, db, branch, password), "renew")
 }

--- a/planetscale/postgres_branches.go
+++ b/planetscale/postgres_branches.go
@@ -194,7 +194,7 @@ func (p *postgresBranchesService) ListClusterSKUs(ctx context.Context, listReq *
 
 // Schema returns the schema for the specified Postgres branch.
 func (p *postgresBranchesService) Schema(ctx context.Context, schemaReq *PostgresBranchSchemaRequest) ([]*PostgresBranchSchema, error) {
-	path := fmt.Sprintf("%s/schema", postgresBranchAPIPath(schemaReq.Organization, schemaReq.Database, schemaReq.Branch))
+	path := path.Join(postgresBranchAPIPath(schemaReq.Organization, schemaReq.Database, schemaReq.Branch), "schema")
 	v := url.Values{}
 	if schemaReq.Namespace != "" {
 		v.Set("namespace", schemaReq.Namespace)

--- a/planetscale/postgres_branches.go
+++ b/planetscale/postgres_branches.go
@@ -175,11 +175,7 @@ func (p *postgresBranchesService) ListClusterSKUs(ctx context.Context, listReq *
 		}
 	}
 
-	if vals := defaultOpts.URLValues.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := p.client.newRequest(http.MethodGet, path, nil)
+	req, err := p.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -200,11 +196,7 @@ func (p *postgresBranchesService) Schema(ctx context.Context, schemaReq *Postgre
 		v.Set("namespace", schemaReq.Namespace)
 	}
 
-	if vals := v.Encode(); vals != "" {
-		path += "?" + vals
-	}
-
-	req, err := p.client.newRequest(http.MethodGet, path, nil)
+	req, err := p.client.newRequest(http.MethodGet, path, nil, WithQueryParams(v))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/postgres_branches.go
+++ b/planetscale/postgres_branches.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -136,7 +137,7 @@ func (p *postgresBranchesService) List(ctx context.Context, listReq *ListPostgre
 
 // Get returns a single Postgres branch for the specified organization, database, and branch.
 func (p *postgresBranchesService) Get(ctx context.Context, getReq *GetPostgresBranchRequest) (*PostgresBranch, error) {
-	path := fmt.Sprintf("%s/%s", postgresBranchesAPIPath(getReq.Organization, getReq.Database), getReq.Branch)
+	path := path.Join(postgresBranchesAPIPath(getReq.Organization, getReq.Database), getReq.Branch)
 	req, err := p.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -152,7 +153,7 @@ func (p *postgresBranchesService) Get(ctx context.Context, getReq *GetPostgresBr
 
 // Delete deletes a Postgres branch from the specified organization and database.
 func (p *postgresBranchesService) Delete(ctx context.Context, deleteReq *DeletePostgresBranchRequest) error {
-	path := fmt.Sprintf("%s/%s", postgresBranchesAPIPath(deleteReq.Organization, deleteReq.Database), deleteReq.Branch)
+	path := path.Join(postgresBranchesAPIPath(deleteReq.Organization, deleteReq.Database), deleteReq.Branch)
 	req, err := p.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("error creating http request: %w", err)
@@ -164,7 +165,7 @@ func (p *postgresBranchesService) Delete(ctx context.Context, deleteReq *DeleteP
 
 // ListClusterSKUs returns a list of cluster SKUs for the specified Postgres branch.
 func (p *postgresBranchesService) ListClusterSKUs(ctx context.Context, listReq *ListBranchClusterSKUsRequest, opts ...ListOption) ([]*ClusterSKU, error) {
-	path := fmt.Sprintf("%s/cluster-size-skus", postgresBranchAPIPath(listReq.Organization, listReq.Database, listReq.Branch))
+	path := path.Join(postgresBranchAPIPath(listReq.Organization, listReq.Database, listReq.Branch), "cluster-size-skus")
 
 	defaultOpts := defaultListOptions()
 	for _, opt := range opts {
@@ -217,9 +218,9 @@ func (p *postgresBranchesService) Schema(ctx context.Context, schemaReq *Postgre
 }
 
 func postgresBranchesAPIPath(org, db string) string {
-	return fmt.Sprintf("%s/%s/branches", databasesAPIPath(org), db)
+	return path.Join(databasesAPIPath(org), db, "branches")
 }
 
 func postgresBranchAPIPath(org, db, branch string) string {
-	return fmt.Sprintf("%s/%s", postgresBranchesAPIPath(org, db), branch)
+	return path.Join(postgresBranchesAPIPath(org, db), branch)
 }

--- a/planetscale/service_tokens.go
+++ b/planetscale/service_tokens.go
@@ -2,8 +2,8 @@ package planetscale
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"path"
 )
 
 var _ ServiceTokenService = &serviceTokenService{}
@@ -193,17 +193,17 @@ type serviceTokenGrantsResponse struct {
 }
 
 func serviceTokenAccessAPIPath(org, id string) string {
-	return fmt.Sprintf("%s/%s/access", serviceTokensAPIPath(org), id)
+	return path.Join(serviceTokensAPIPath(org), id, "access")
 }
 
 func serviceTokenGrantsAPIPath(org, id string) string {
-	return fmt.Sprintf("%s/%s/grants", serviceTokensAPIPath(org), id)
+	return path.Join(serviceTokensAPIPath(org), id, "grants")
 }
 
 func serviceTokensAPIPath(org string) string {
-	return fmt.Sprintf("v1/organizations/%s/service-tokens", org)
+	return path.Join("v1/organizations", org, "service-tokens")
 }
 
 func serviceTokenAPIPath(org, id string) string {
-	return fmt.Sprintf("%s/%s", serviceTokensAPIPath(org), id)
+	return path.Join(serviceTokensAPIPath(org), id)
 }

--- a/planetscale/workflows.go
+++ b/planetscale/workflows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -268,8 +269,8 @@ func (ws *workflowsService) Create(ctx context.Context, createReq *CreateWorkflo
 }
 
 func (ws *workflowsService) VerifyData(ctx context.Context, verifyDataReq *VerifyDataWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/verify-data", workflowAPIPath(verifyDataReq.Organization, verifyDataReq.Database, verifyDataReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(verifyDataReq.Organization, verifyDataReq.Database, verifyDataReq.WorkflowNumber), "verify-data")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -285,8 +286,8 @@ func (ws *workflowsService) VerifyData(ctx context.Context, verifyDataReq *Verif
 }
 
 func (ws *workflowsService) SwitchReplicas(ctx context.Context, switchReplicasReq *SwitchReplicasWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/switch-replicas", workflowAPIPath(switchReplicasReq.Organization, switchReplicasReq.Database, switchReplicasReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(switchReplicasReq.Organization, switchReplicasReq.Database, switchReplicasReq.WorkflowNumber), "switch-replicas")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -302,8 +303,8 @@ func (ws *workflowsService) SwitchReplicas(ctx context.Context, switchReplicasRe
 }
 
 func (ws *workflowsService) SwitchPrimaries(ctx context.Context, switchPrimariesReq *SwitchPrimariesWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/switch-primaries", workflowAPIPath(switchPrimariesReq.Organization, switchPrimariesReq.Database, switchPrimariesReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(switchPrimariesReq.Organization, switchPrimariesReq.Database, switchPrimariesReq.WorkflowNumber), "switch-primaries")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -319,8 +320,8 @@ func (ws *workflowsService) SwitchPrimaries(ctx context.Context, switchPrimaries
 }
 
 func (ws *workflowsService) ReverseTraffic(ctx context.Context, reverseTrafficReq *ReverseTrafficWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/reverse-traffic", workflowAPIPath(reverseTrafficReq.Organization, reverseTrafficReq.Database, reverseTrafficReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(reverseTrafficReq.Organization, reverseTrafficReq.Database, reverseTrafficReq.WorkflowNumber), "reverse-traffic")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -336,8 +337,8 @@ func (ws *workflowsService) ReverseTraffic(ctx context.Context, reverseTrafficRe
 }
 
 func (ws *workflowsService) Cutover(ctx context.Context, cutoverReq *CutoverWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/cutover", workflowAPIPath(cutoverReq.Organization, cutoverReq.Database, cutoverReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(cutoverReq.Organization, cutoverReq.Database, cutoverReq.WorkflowNumber), "cutover")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -353,8 +354,8 @@ func (ws *workflowsService) Cutover(ctx context.Context, cutoverReq *CutoverWork
 }
 
 func (ws *workflowsService) ReverseCutover(ctx context.Context, reverseCutoverReq *ReverseCutoverWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/reverse-cutover", workflowAPIPath(reverseCutoverReq.Organization, reverseCutoverReq.Database, reverseCutoverReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(reverseCutoverReq.Organization, reverseCutoverReq.Database, reverseCutoverReq.WorkflowNumber), "reverse-cutover")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -370,8 +371,8 @@ func (ws *workflowsService) ReverseCutover(ctx context.Context, reverseCutoverRe
 }
 
 func (ws *workflowsService) Complete(ctx context.Context, completeReq *CompleteWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/complete", workflowAPIPath(completeReq.Organization, completeReq.Database, completeReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(completeReq.Organization, completeReq.Database, completeReq.WorkflowNumber), "complete")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -387,8 +388,8 @@ func (ws *workflowsService) Complete(ctx context.Context, completeReq *CompleteW
 }
 
 func (ws *workflowsService) Retry(ctx context.Context, retryReq *RetryWorkflowRequest) (*Workflow, error) {
-	path := fmt.Sprintf("%s/retry", workflowAPIPath(retryReq.Organization, retryReq.Database, retryReq.WorkflowNumber))
-	req, err := ws.client.newRequest(http.MethodPatch, path, nil)
+	pathStr := path.Join(workflowAPIPath(retryReq.Organization, retryReq.Database, retryReq.WorkflowNumber), "retry")
+	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
@@ -420,9 +421,9 @@ func (ws *workflowsService) Cancel(ctx context.Context, cancelReq *CancelWorkflo
 	return workflow, nil
 }
 func workflowsAPIPath(org, db string) string {
-	return fmt.Sprintf("%s/%s/workflows", databasesAPIPath(org), db)
+	return path.Join(databasesAPIPath(org), db, "workflows")
 }
 
 func workflowAPIPath(org, db string, number uint64) string {
-	return fmt.Sprintf("%s/%d", workflowsAPIPath(org, db), number)
+	return path.Join(workflowsAPIPath(org, db), fmt.Sprintf("%d", number))
 }


### PR DESCRIPTION
As follow-up to #257, this implements some light refactoring of how we handle query parameters and also using `path.Join` instead of `fmt.Sprintf` for creating URL paths. I think these ways are a bit more idiomatic Go-wise and will be a lot more extensible in the future.