### PR TITLE
Add support for listing rates specifically for Postgres

### DIFF
--- a/planetscale/organizations.go
+++ b/planetscale/organizations.go
@@ -34,6 +34,7 @@ type ListOrganizationRegionsRequest struct {
 // ListOrganizationClusterSKUsRequest encapsulates the request for getting a list of Cluster SKUs for an organization.
 type ListOrganizationClusterSKUsRequest struct {
 	Organization string
+	Postgres     bool
 }
 
 // ClusterSKU represents a SKU for a PlanetScale cluster
@@ -139,6 +140,10 @@ func (o *organizationsService) ListClusterSKUs(ctx context.Context, listReq *Lis
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if listReq.Postgres {
+		defaultOpts.URLValues.Set("postgresql", "true")
 	}
 
 	req, err := o.client.newRequest(http.MethodGet, path, nil, WithQueryParams(*defaultOpts.URLValues))

--- a/planetscale/organizations_test.go
+++ b/planetscale/organizations_test.go
@@ -185,6 +185,65 @@ func TestOrganizations_ListClusterSKUs(t *testing.T) {
 	c.Assert(orgs, qt.DeepEquals, want)
 }
 
+func TestOrganizations_ListClusterSKUsPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+
+		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-cool-org/cluster-size-skus?postgresql=true")
+		out := `[
+		{
+			"name": "PS_10",
+			"type": "ClusterSizeSku",
+			"display_name": "PS-10",
+			"cpu": "1/8",
+			"provider_instance_type": null,
+			"storage": null,
+			"ram": 1,
+			"metal": true,
+			"enabled": true,
+			"provider": null,
+			"rate": null,
+			"replica_rate": null,
+			"default_vtgate": "VTG_5",
+			"default_vtgate_rate": null,
+			"sort_order": 1
+		}
+
+	]`
+
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	orgs, err := client.Organizations.ListClusterSKUs(ctx, &ListOrganizationClusterSKUsRequest{
+		Organization: "my-cool-org",
+		Postgres:     true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	want := []*ClusterSKU{
+		{
+			Name:          "PS_10",
+			DisplayName:   "PS-10",
+			CPU:           "1/8",
+			Memory:        1,
+			Enabled:       true,
+			DefaultVTGate: "VTG_5",
+			SortOrder:     1,
+			Metal:         true,
+		},
+	}
+
+	c.Assert(orgs, qt.DeepEquals, want)
+}
+
 func TestOrganizations_ListClusterSKUsWithRates(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
This pull request implements the flag for showing Postgres rates from the `ListClusterSKUs` endpoint. 