### PR TITLE
Add `omitempty` for cluster size on database creation

### DIFF
--- a/planetscale/databases.go
+++ b/planetscale/databases.go
@@ -14,7 +14,7 @@ type CreateDatabaseRequest struct {
 	Name         string `json:"name"`
 	Notes        string `json:"notes,omitempty"`
 	Region       string `json:"region,omitempty"`
-	ClusterSize  string `json:"cluster_size"`
+	ClusterSize  string `json:"cluster_size,omitempty"`
 	Kind         string `json:"kind,omitempty"`
 }
 


### PR DESCRIPTION
If the cluster size is empty, we should omit it so the API can just default to the default size within the database.