### PR TITLE
Add wrappers for the Postgres roles API

### DIFF
--- a/planetscale/postgres_roles.go
+++ b/planetscale/postgres_roles.go
@@ -41,11 +41,12 @@ type GetPostgresRoleRequest struct {
 
 // CreatePostgresRoleRequest encapsulates the request for creating role credentials for a database branch.
 type CreatePostgresRoleRequest struct {
-	Organization string `json:"-"`
-	Database     string `json:"-"`
-	Branch       string `json:"-"`
-	Name         string `json:"name"`
-	TTL          int    `json:"ttl,omitempty"`
+	Organization    string   `json:"-"`
+	Database        string   `json:"-"`
+	Branch          string   `json:"-"`
+	Name            string   `json:"name"`
+	TTL             int      `json:"ttl,omitempty"`
+	InheritedRoles  []string `json:"inherited_roles,omitempty"`
 }
 
 // UpdatePostgresRoleRequest encapsulates the request for updating a role name for a database branch.

--- a/planetscale/postgres_roles.go
+++ b/planetscale/postgres_roles.go
@@ -41,12 +41,12 @@ type GetPostgresRoleRequest struct {
 
 // CreatePostgresRoleRequest encapsulates the request for creating role credentials for a database branch.
 type CreatePostgresRoleRequest struct {
-	Organization    string   `json:"-"`
-	Database        string   `json:"-"`
-	Branch          string   `json:"-"`
-	Name            string   `json:"name"`
-	TTL             int      `json:"ttl,omitempty"`
-	InheritedRoles  []string `json:"inherited_roles,omitempty"`
+	Organization   string   `json:"-"`
+	Database       string   `json:"-"`
+	Branch         string   `json:"-"`
+	Name           string   `json:"name"`
+	TTL            int      `json:"ttl,omitempty"`
+	InheritedRoles []string `json:"inherited_roles,omitempty"`
 }
 
 // UpdatePostgresRoleRequest encapsulates the request for updating a role name for a database branch.

--- a/planetscale/postgres_roles.go
+++ b/planetscale/postgres_roles.go
@@ -71,7 +71,8 @@ type DeletePostgresRoleRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
-	RoleId       string
+	RoleId       string `json:"-"`
+	Successor    string `json:"successor,omitempty"`
 }
 
 // ResetDefaultRoleRequest encapsulates the request for resetting the default role of a Postgres database branch.
@@ -212,7 +213,7 @@ func (p *postgresRolesService) Renew(ctx context.Context, renewReq *RenewPostgre
 // Delete role credentials for a database branch.
 func (p *postgresRolesService) Delete(ctx context.Context, deleteReq *DeletePostgresRoleRequest) error {
 	pathStr := postgresBranchRoleAPIPath(deleteReq.Organization, deleteReq.Database, deleteReq.Branch, deleteReq.RoleId)
-	req, err := p.client.newRequest(http.MethodDelete, pathStr, nil)
+	req, err := p.client.newRequest(http.MethodDelete, pathStr, deleteReq)
 	if err != nil {
 		return fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/postgres_roles.go
+++ b/planetscale/postgres_roles.go
@@ -64,7 +64,6 @@ type RenewPostgresRoleRequest struct {
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
 	RoleId       string `json:"-"`
-	TTL          int    `json:"ttl,omitempty"`
 }
 
 // DeletePostgresRoleRequest encapsulates the request for deleting role credentials for a database branch.

--- a/planetscale/postgres_roles_test.go
+++ b/planetscale/postgres_roles_test.go
@@ -369,7 +369,6 @@ func TestPostgresRoles_Renew(t *testing.T) {
 		Database:     db,
 		Branch:       branch,
 		RoleId:       testRoleID,
-		TTL:          7200,
 	})
 
 	want := &PostgresRole{

--- a/planetscale/postgres_roles_test.go
+++ b/planetscale/postgres_roles_test.go
@@ -259,7 +259,7 @@ func TestPostgresRoles_Create(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, qt.Equals, "POST")
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/roles")
-		
+
 		// Verify request body
 		body, err := io.ReadAll(r.Body)
 		c.Assert(err, qt.IsNil)
@@ -269,7 +269,7 @@ func TestPostgresRoles_Create(t *testing.T) {
 		c.Assert(reqBody.Name, qt.Equals, "new-role")
 		c.Assert(reqBody.TTL, qt.Equals, 3600)
 		c.Assert(reqBody.InheritedRoles, qt.DeepEquals, []string{"pg_read_all_data", "pg_write_all_data"})
-		
+
 		w.WriteHeader(200)
 		out := fmt.Sprintf(`{
     "id": "%s",
@@ -321,7 +321,7 @@ func TestPostgresRoles_Update(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, qt.Equals, "PATCH")
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/roles/AbC123xYz")
-		
+
 		// Verify request body
 		body, err := io.ReadAll(r.Body)
 		c.Assert(err, qt.IsNil)
@@ -329,7 +329,7 @@ func TestPostgresRoles_Update(t *testing.T) {
 		err = json.Unmarshal(body, &reqBody)
 		c.Assert(err, qt.IsNil)
 		c.Assert(reqBody.Name, qt.Equals, "updated-role")
-		
+
 		w.WriteHeader(200)
 		out := fmt.Sprintf(`{
     "id": "%s",
@@ -429,7 +429,7 @@ func TestPostgresRoles_Delete(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, qt.Equals, "DELETE")
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/roles/AbC123xYz")
-		
+
 		// Verify request body
 		body, err := io.ReadAll(r.Body)
 		c.Assert(err, qt.IsNil)
@@ -437,7 +437,7 @@ func TestPostgresRoles_Delete(t *testing.T) {
 		err = json.Unmarshal(body, &reqBody)
 		c.Assert(err, qt.IsNil)
 		c.Assert(reqBody.Successor, qt.Equals, "default")
-		
+
 		w.WriteHeader(204)
 	}))
 

--- a/planetscale/postgres_roles_test.go
+++ b/planetscale/postgres_roles_test.go
@@ -405,6 +405,7 @@ func TestPostgresRoles_Delete(t *testing.T) {
 		Database:     db,
 		Branch:       branch,
 		RoleId:       testRoleID,
+		Successor:    "default",
 	})
 
 	c.Assert(err, qt.IsNil)

--- a/planetscale/postgres_roles_test.go
+++ b/planetscale/postgres_roles_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 )
+
+const testRoleID = "AbC123xYz"
 
 func TestResetDefaultRole(t *testing.T) {
 	c := qt.New(t)
@@ -55,4 +58,354 @@ func TestResetDefaultRole(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_List(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{
+    "data":
+    [
+        {
+            "id": "AbC123xYz",
+            "name": "test-role",
+            "access_host_url": "test.planetscale.com",
+            "database_name": "test-db",
+            "username": "test-user",
+            "created_at": "2021-01-14T10:19:23.000Z"
+        }
+    ]
+}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	roles, err := client.PostgresRoles.List(ctx, &ListPostgresRolesRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+	})
+
+	want := []*PostgresRole{
+		{
+			ID:            testRoleID,
+			Name:          "test-role",
+			AccessHostURL: "test.planetscale.com",
+			DatabaseName:  "test-db",
+			Username:      "test-user",
+			CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		},
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(roles, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_ListEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := `{"data":[]}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	roles, err := client.PostgresRoles.List(ctx, &ListPostgresRolesRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(roles, qt.HasLen, 0)
+}
+
+func TestPostgresRoles_ListWithPagination(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify pagination parameters are included in the request
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "50")
+
+		w.WriteHeader(200)
+		out := `{
+    "data":
+    [
+        {
+            "id": "AbC123xYz",
+            "name": "test-role",
+            "access_host_url": "test.planetscale.com",
+            "database_name": "test-db",
+            "username": "test-user",
+            "created_at": "2021-01-14T10:19:23.000Z"
+        }
+    ]
+}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	roles, err := client.PostgresRoles.List(ctx, &ListPostgresRolesRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+	}, WithPage(2), WithPerPage(50))
+
+	want := []*PostgresRole{
+		{
+			ID:            testRoleID,
+			Name:          "test-role",
+			AccessHostURL: "test.planetscale.com",
+			DatabaseName:  "test-db",
+			Username:      "test-user",
+			CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		},
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(roles, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_Get(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{
+    "id": "%s",
+    "name": "test-role",
+    "access_host_url": "test.planetscale.com",
+    "database_name": "test-db",
+    "password": "secret-password",
+    "username": "test-user",
+    "created_at": "2021-01-14T10:19:23.000Z"
+}`, testRoleID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	role, err := client.PostgresRoles.Get(ctx, &GetPostgresRoleRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		RoleId:       testRoleID,
+	})
+
+	want := &PostgresRole{
+		ID:            testRoleID,
+		Name:          "test-role",
+		AccessHostURL: "test.planetscale.com",
+		DatabaseName:  "test-db",
+		Password:      "secret-password",
+		Username:      "test-user",
+		CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_Create(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{
+    "id": "%s",
+    "name": "new-role",
+    "access_host_url": "test.planetscale.com",
+    "database_name": "test-db",
+    "password": "generated-password",
+    "username": "new-user",
+    "created_at": "2021-01-14T10:19:23.000Z"
+}`, testRoleID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	role, err := client.PostgresRoles.Create(ctx, &CreatePostgresRoleRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		Name:         "new-role",
+		TTL:          3600,
+	})
+
+	want := &PostgresRole{
+		ID:            testRoleID,
+		Name:          "new-role",
+		AccessHostURL: "test.planetscale.com",
+		DatabaseName:  "test-db",
+		Password:      "generated-password",
+		Username:      "new-user",
+		CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_Update(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{
+    "id": "%s",
+    "name": "updated-role",
+    "access_host_url": "test.planetscale.com",
+    "database_name": "test-db",
+    "password": "existing-password",
+    "username": "existing-user",
+    "created_at": "2021-01-14T10:19:23.000Z"
+}`, testRoleID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	role, err := client.PostgresRoles.Update(ctx, &UpdatePostgresRoleRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		RoleId:       testRoleID,
+		Name:         "updated-role",
+	})
+
+	want := &PostgresRole{
+		ID:            testRoleID,
+		Name:          "updated-role",
+		AccessHostURL: "test.planetscale.com",
+		DatabaseName:  "test-db",
+		Password:      "existing-password",
+		Username:      "existing-user",
+		CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_Renew(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{
+    "id": "%s",
+    "name": "existing-role",
+    "access_host_url": "test.planetscale.com",
+    "database_name": "test-db",
+    "password": "renewed-password",
+    "username": "existing-user",
+    "created_at": "2021-01-14T10:19:23.000Z"
+}`, testRoleID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	role, err := client.PostgresRoles.Renew(ctx, &RenewPostgresRoleRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		RoleId:       testRoleID,
+		TTL:          7200,
+	})
+
+	want := &PostgresRole{
+		ID:            testRoleID,
+		Name:          "existing-role",
+		AccessHostURL: "test.planetscale.com",
+		DatabaseName:  "test-db",
+		Password:      "renewed-password",
+		Username:      "existing-user",
+		CreatedAt:     time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	err = client.PostgresRoles.Delete(ctx, &DeletePostgresRoleRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		RoleId:       testRoleID,
+	})
+
+	c.Assert(err, qt.IsNil)
 }

--- a/planetscale/postgres_roles_test.go
+++ b/planetscale/postgres_roles_test.go
@@ -268,11 +268,12 @@ func TestPostgresRoles_Create(t *testing.T) {
 	branch := "my-branch"
 
 	role, err := client.PostgresRoles.Create(ctx, &CreatePostgresRoleRequest{
-		Organization: org,
-		Database:     db,
-		Branch:       branch,
-		Name:         "new-role",
-		TTL:          3600,
+		Organization:   org,
+		Database:       db,
+		Branch:         branch,
+		Name:           "new-role",
+		TTL:            3600,
+		InheritedRoles: []string{"pg_read_all_data", "pg_write_all_data"},
 	})
 
 	want := &PostgresRole{

--- a/planetscale/workflows.go
+++ b/planetscale/workflows.go
@@ -254,7 +254,6 @@ func (ws *workflowsService) Get(ctx context.Context, getReq *GetWorkflowRequest)
 
 func (ws *workflowsService) Create(ctx context.Context, createReq *CreateWorkflowRequest) (*Workflow, error) {
 	req, err := ws.client.newRequest(http.MethodPost, workflowsAPIPath(createReq.Organization, createReq.Database), createReq)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -271,7 +270,6 @@ func (ws *workflowsService) Create(ctx context.Context, createReq *CreateWorkflo
 func (ws *workflowsService) VerifyData(ctx context.Context, verifyDataReq *VerifyDataWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(verifyDataReq.Organization, verifyDataReq.Database, verifyDataReq.WorkflowNumber), "verify-data")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -288,7 +286,6 @@ func (ws *workflowsService) VerifyData(ctx context.Context, verifyDataReq *Verif
 func (ws *workflowsService) SwitchReplicas(ctx context.Context, switchReplicasReq *SwitchReplicasWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(switchReplicasReq.Organization, switchReplicasReq.Database, switchReplicasReq.WorkflowNumber), "switch-replicas")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -305,7 +302,6 @@ func (ws *workflowsService) SwitchReplicas(ctx context.Context, switchReplicasRe
 func (ws *workflowsService) SwitchPrimaries(ctx context.Context, switchPrimariesReq *SwitchPrimariesWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(switchPrimariesReq.Organization, switchPrimariesReq.Database, switchPrimariesReq.WorkflowNumber), "switch-primaries")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -322,7 +318,6 @@ func (ws *workflowsService) SwitchPrimaries(ctx context.Context, switchPrimaries
 func (ws *workflowsService) ReverseTraffic(ctx context.Context, reverseTrafficReq *ReverseTrafficWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(reverseTrafficReq.Organization, reverseTrafficReq.Database, reverseTrafficReq.WorkflowNumber), "reverse-traffic")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -339,7 +334,6 @@ func (ws *workflowsService) ReverseTraffic(ctx context.Context, reverseTrafficRe
 func (ws *workflowsService) Cutover(ctx context.Context, cutoverReq *CutoverWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(cutoverReq.Organization, cutoverReq.Database, cutoverReq.WorkflowNumber), "cutover")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -356,7 +350,6 @@ func (ws *workflowsService) Cutover(ctx context.Context, cutoverReq *CutoverWork
 func (ws *workflowsService) ReverseCutover(ctx context.Context, reverseCutoverReq *ReverseCutoverWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(reverseCutoverReq.Organization, reverseCutoverReq.Database, reverseCutoverReq.WorkflowNumber), "reverse-cutover")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -373,7 +366,6 @@ func (ws *workflowsService) ReverseCutover(ctx context.Context, reverseCutoverRe
 func (ws *workflowsService) Complete(ctx context.Context, completeReq *CompleteWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(completeReq.Organization, completeReq.Database, completeReq.WorkflowNumber), "complete")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -390,7 +382,6 @@ func (ws *workflowsService) Complete(ctx context.Context, completeReq *CompleteW
 func (ws *workflowsService) Retry(ctx context.Context, retryReq *RetryWorkflowRequest) (*Workflow, error) {
 	pathStr := path.Join(workflowAPIPath(retryReq.Organization, retryReq.Database, retryReq.WorkflowNumber), "retry")
 	req, err := ws.client.newRequest(http.MethodPatch, pathStr, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -407,7 +398,6 @@ func (ws *workflowsService) Retry(ctx context.Context, retryReq *RetryWorkflowRe
 func (ws *workflowsService) Cancel(ctx context.Context, cancelReq *CancelWorkflowRequest) (*Workflow, error) {
 	path := workflowAPIPath(cancelReq.Organization, cancelReq.Database, cancelReq.WorkflowNumber)
 	req, err := ws.client.newRequest(http.MethodDelete, path, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}
@@ -420,6 +410,7 @@ func (ws *workflowsService) Cancel(ctx context.Context, cancelReq *CancelWorkflo
 
 	return workflow, nil
 }
+
 func workflowsAPIPath(org, db string) string {
 	return path.Join(databasesAPIPath(org), db, "workflows")
 }


### PR DESCRIPTION
This adds Go wrappers for the new Postgres Roles endpoints: Create, List, Get, Renew, Update, Delete.