### PR TITLE
Add WithPostgreSQL() ListOption for cluster size queries

### DIFF
--- a/planetscale/client.go
+++ b/planetscale/client.go
@@ -116,6 +116,14 @@ func WithRates() ListOption {
 	}
 }
 
+// WithPostgreSQL returns a ListOption that sets the "postgresql" URL parameter.
+func WithPostgreSQL() ListOption {
+	return func(opt *ListOptions) error {
+		opt.URLValues.Set("postgresql", "true")
+		return nil
+	}
+}
+
 // WithRegion returns a ListOption sets the "region" URL parameter.
 func WithRegion(region string) ListOption {
 	return func(opt *ListOptions) error {


### PR DESCRIPTION
Adds WithPostgreSQL() function that sets the "postgresql=true" query parameter, allowing clients to fetch PostgreSQL-specific cluster sizes.

- Add WithPostgreSQL() function to client.go alongside other WithXXX functions
- Add comprehensive test TestOrganizations_ListClusterSKUsWithPostgreSQL
- Follows same pattern as WithRates() and WithRegion()
- Enables proper PostgreSQL cluster size support in CLI tools