### PR TITLE
ci: pin actions/checkout to SHA

### DIFF
--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb # v1.257.0
         with:


### PR DESCRIPTION
This should fix the CI error in the build for https://github.com/planetscale/planetscale-go/pull/307

```
git ls-remote https://github.com/actions/checkout refs/tags/v4.3.1
34e114876b0b11c390a56381ad16ebd13914f8d5	refs/tags/v4.3.1
```