### PR TITLE
Update MoveTables Cancel to async

### DIFF
--- a/planetscale/vtctld_move_tables.go
+++ b/planetscale/vtctld_move_tables.go
@@ -17,7 +17,7 @@ type MoveTablesService interface {
 	Status(context.Context, *MoveTablesStatusRequest) (json.RawMessage, error)
 	SwitchTraffic(context.Context, *MoveTablesSwitchTrafficRequest) (*VtctldOperationReference, error)
 	ReverseTraffic(context.Context, *MoveTablesReverseTrafficRequest) (*VtctldOperationReference, error)
-	Cancel(context.Context, *MoveTablesCancelRequest) (json.RawMessage, error)
+	Cancel(context.Context, *MoveTablesCancelRequest) (*VtctldOperationReference, error)
 	Complete(context.Context, *MoveTablesCompleteRequest) (*VtctldOperationReference, error)
 }
 
@@ -171,17 +171,9 @@ func (s *moveTablesService) ReverseTraffic(ctx context.Context, req *MoveTablesR
 	return s.enqueueOperation(ctx, p, req)
 }
 
-func (s *moveTablesService) Cancel(ctx context.Context, req *MoveTablesCancelRequest) (json.RawMessage, error) {
+func (s *moveTablesService) Cancel(ctx context.Context, req *MoveTablesCancelRequest) (*VtctldOperationReference, error) {
 	p := path.Join(moveTablesWorkflowAPIPath(req.Organization, req.Database, req.Branch, req.Workflow), "cancel")
-	httpReq, err := s.client.newRequest(http.MethodPost, p, req)
-	if err != nil {
-		return nil, fmt.Errorf("error creating http request: %w", err)
-	}
-	resp := &vtctldDataResponse{}
-	if err := s.client.do(ctx, httpReq, resp); err != nil {
-		return nil, err
-	}
-	return resp.Data, nil
+	return s.enqueueOperation(ctx, p, req)
 }
 
 func (s *moveTablesService) Complete(ctx context.Context, req *MoveTablesCompleteRequest) (*VtctldOperationReference, error) {

--- a/planetscale/vtctld_move_tables_test.go
+++ b/planetscale/vtctld_move_tables_test.go
@@ -419,8 +419,8 @@ func TestMoveTables_Cancel(t *testing.T) {
 		c.Assert(hasKeepData, qt.IsFalse)
 		c.Assert(hasKeepRoutingRules, qt.IsFalse)
 
-		w.WriteHeader(200)
-		_, err = w.Write([]byte(`{"data":{"result":"ok"}}`))
+		w.WriteHeader(202)
+		_, err = w.Write([]byte(`{"id":"cancel-op-123"}`))
 		c.Assert(err, qt.IsNil)
 	}))
 	defer ts.Close()
@@ -429,7 +429,7 @@ func TestMoveTables_Cancel(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	ctx := context.Background()
-	data, err := client.MoveTables.Cancel(ctx, &MoveTablesCancelRequest{
+	op, err := client.MoveTables.Cancel(ctx, &MoveTablesCancelRequest{
 		Organization:   "my-org",
 		Database:       "my-db",
 		Branch:         "my-branch",
@@ -437,7 +437,7 @@ func TestMoveTables_Cancel(t *testing.T) {
 		TargetKeyspace: "target",
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(data), qt.Equals, `{"result":"ok"}`)
+	c.Assert(op.ID, qt.Equals, "cancel-op-123")
 }
 
 func TestMoveTables_CancelWithExplicitFalseValues(t *testing.T) {
@@ -458,8 +458,8 @@ func TestMoveTables_CancelWithExplicitFalseValues(t *testing.T) {
 		c.Assert(keepData, qt.Equals, false)
 		c.Assert(keepRoutingRules, qt.Equals, false)
 
-		w.WriteHeader(200)
-		_, err = w.Write([]byte(`{"data":{"result":"ok"}}`))
+		w.WriteHeader(202)
+		_, err = w.Write([]byte(`{"id":"cancel-op-456"}`))
 		c.Assert(err, qt.IsNil)
 	}))
 	defer ts.Close()
@@ -469,7 +469,7 @@ func TestMoveTables_CancelWithExplicitFalseValues(t *testing.T) {
 
 	falseValue := false
 	ctx := context.Background()
-	data, err := client.MoveTables.Cancel(ctx, &MoveTablesCancelRequest{
+	op, err := client.MoveTables.Cancel(ctx, &MoveTablesCancelRequest{
 		Organization:     "my-org",
 		Database:         "my-db",
 		Branch:           "my-branch",
@@ -479,7 +479,7 @@ func TestMoveTables_CancelWithExplicitFalseValues(t *testing.T) {
 		KeepRoutingRules: &falseValue,
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(data), qt.Equals, `{"result":"ok"}`)
+	c.Assert(op.ID, qt.Equals, "cancel-op-456")
 }
 
 func TestMoveTables_Complete(t *testing.T) {


### PR DESCRIPTION
Updates the `MoveTables Cancel` operations to be async, this avoids running into our http request timeouts in the API for potentially long running `Cancel` requests