### PR TITLE
Add throttler client methods to VtctldService

### DIFF
--- a/planetscale/vtctld_general.go
+++ b/planetscale/vtctld_general.go
@@ -18,6 +18,9 @@ type VtctldService interface {
 	ListTablets(context.Context, *ListBranchTabletsRequest) ([]*TabletGroup, error)
 	StartWorkflow(context.Context, *VtctldStartWorkflowRequest) (json.RawMessage, error)
 	StopWorkflow(context.Context, *VtctldStopWorkflowRequest) (json.RawMessage, error)
+	GetThrottlerStatus(context.Context, *VtctldGetThrottlerStatusRequest) (json.RawMessage, error)
+	CheckThrottler(context.Context, *VtctldCheckThrottlerRequest) (json.RawMessage, error)
+	UpdateThrottlerConfig(context.Context, *VtctldUpdateThrottlerConfigRequest) (json.RawMessage, error)
 	GetOperation(context.Context, *GetVtctldOperationRequest) (*VtctldOperation, error)
 }
 
@@ -53,6 +56,72 @@ type VtctldStopWorkflowRequest struct {
 	Branch       string `json:"-"`
 	Workflow     string `json:"-"`
 	Keyspace     string `json:"keyspace"`
+}
+
+// VtctldGetThrottlerStatusRequest is a request for reading the tablet throttler
+// status from a single tablet. The tablet is identified by its alias, as
+// discovered via ListTablets.
+type VtctldGetThrottlerStatusRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+	TabletAlias  string `json:"-"`
+}
+
+// VtctldCheckThrottlerRequest is a request for issuing a throttler check against
+// a single tablet. The tablet is identified by its alias, as discovered via
+// ListTablets.
+type VtctldCheckThrottlerRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+
+	TabletAlias string `json:"tablet_alias"`
+	// AppName is the app to issue the check on behalf of (e.g. "online-ddl"). If
+	// empty, the throttler's default app is used.
+	AppName string `json:"app_name,omitempty"`
+	// Scope is the scope of the check, either "shard" or "self". If empty, the
+	// throttler's default scope is used.
+	Scope string `json:"scope,omitempty"`
+	// SkipRequestHeartbeats instructs the throttler not to renew its heartbeat
+	// lease while serving this check.
+	SkipRequestHeartbeats *bool `json:"skip_request_heartbeats,omitempty"`
+	// OkIfNotExists instructs the throttler to return OK even if the requested
+	// metric does not exist.
+	OkIfNotExists *bool `json:"ok_if_not_exists,omitempty"`
+}
+
+// VtctldThrottledAppConfig configures a single throttled app rule for
+// UpdateThrottlerConfig.
+type VtctldThrottledAppConfig struct {
+	// Name is the app to throttle (e.g. "online-ddl", "vreplication", or an
+	// Online DDL migration UUID).
+	Name string `json:"name"`
+	// Ratio is the fraction of operations to throttle for the app, 0.00-1.00 in
+	// increments of 0.01.
+	Ratio *float64 `json:"ratio,omitempty"`
+	// ExpireAt is an optional RFC3339 expiration time for the app rule. It must
+	// be in the future. Omit to throttle until changed.
+	ExpireAt string `json:"expire_at,omitempty"`
+}
+
+// VtctldUpdateThrottlerConfigRequest is a request for updating the tablet
+// throttler configuration for a keyspace.
+type VtctldUpdateThrottlerConfigRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+
+	Keyspace string `json:"keyspace"`
+	// Enabled controls whether the tablet throttler is enabled for the keyspace.
+	// It is required: the API has no tri-state, so omitting it would disable the
+	// throttler.
+	Enabled bool `json:"enabled"`
+	// Threshold is the threshold for the default throttler check (replication lag
+	// in seconds). It must be >= 0; the server defaults to 5.0 when omitted.
+	Threshold *float64 `json:"threshold,omitempty"`
+	// Apps configures zero or more per-app throttling rules.
+	Apps []VtctldThrottledAppConfig `json:"apps,omitempty"`
 }
 
 type vtctldService struct {
@@ -127,6 +196,54 @@ func (s *vtctldService) StartWorkflow(ctx context.Context, req *VtctldStartWorkf
 func (s *vtctldService) StopWorkflow(ctx context.Context, req *VtctldStopWorkflowRequest) (json.RawMessage, error) {
 	p := path.Join(vtctldWorkflowAPIPath(req.Organization, req.Database, req.Branch, req.Workflow), "stop")
 	httpReq, err := s.client.newRequest(http.MethodPost, p, req)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+	resp := &vtctldDataResponse{}
+	if err := s.client.do(ctx, httpReq, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func vtctldThrottlerAPIPath(org, db, branch string) string {
+	return path.Join(databaseBranchAPIPath(org, db, branch), "vtctld", "throttler")
+}
+
+// GetThrottlerStatus reads the tablet throttler status from a single tablet.
+func (s *vtctldService) GetThrottlerStatus(ctx context.Context, req *VtctldGetThrottlerStatusRequest) (json.RawMessage, error) {
+	p := path.Join(vtctldThrottlerAPIPath(req.Organization, req.Database, req.Branch), "status")
+	v := url.Values{}
+	v.Set("tablet_alias", req.TabletAlias)
+	httpReq, err := s.client.newRequest(http.MethodGet, p, nil, WithQueryParams(v))
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+	resp := &vtctldDataResponse{}
+	if err := s.client.do(ctx, httpReq, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// CheckThrottler issues a throttler check against a single tablet.
+func (s *vtctldService) CheckThrottler(ctx context.Context, req *VtctldCheckThrottlerRequest) (json.RawMessage, error) {
+	p := path.Join(vtctldThrottlerAPIPath(req.Organization, req.Database, req.Branch), "check")
+	httpReq, err := s.client.newRequest(http.MethodPost, p, req)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+	resp := &vtctldDataResponse{}
+	if err := s.client.do(ctx, httpReq, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// UpdateThrottlerConfig updates the tablet throttler configuration for a keyspace.
+func (s *vtctldService) UpdateThrottlerConfig(ctx context.Context, req *VtctldUpdateThrottlerConfigRequest) (json.RawMessage, error) {
+	p := path.Join(vtctldThrottlerAPIPath(req.Organization, req.Database, req.Branch), "config")
+	httpReq, err := s.client.newRequest(http.MethodPut, p, req)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/vtctld_general_test.go
+++ b/planetscale/vtctld_general_test.go
@@ -240,3 +240,194 @@ func TestVtctld_ListKeyspaces_NoNameFilter(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(data), qt.Equals, `{"result":"ok"}`)
 }
+
+func float64Ptr(v float64) *float64 {
+	return &v
+}
+
+func TestVtctld_GetThrottlerStatus(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/throttler/status")
+		c.Assert(r.URL.Query().Get("tablet_alias"), qt.Equals, "zone1-0000000100")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"data":{"keyspace":"commerce","enabled":true}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	data, err := client.Vtctld.GetThrottlerStatus(ctx, &VtctldGetThrottlerStatusRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		TabletAlias:  "zone1-0000000100",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, `{"keyspace":"commerce","enabled":true}`)
+}
+
+func TestVtctld_CheckThrottler(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/throttler/check")
+
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["tablet_alias"], qt.Equals, "zone1-0000000100")
+		c.Assert(body["app_name"], qt.Equals, "online-ddl")
+		c.Assert(body["scope"], qt.Equals, "self")
+		c.Assert(body["skip_request_heartbeats"], qt.Equals, true)
+		c.Assert(body["ok_if_not_exists"], qt.Equals, true)
+
+		w.WriteHeader(200)
+		_, err = w.Write([]byte(`{"data":{"response_code":"THROTTLER_RESPONSE_CODE_OK"}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	data, err := client.Vtctld.CheckThrottler(ctx, &VtctldCheckThrottlerRequest{
+		Organization:          "my-org",
+		Database:              "my-db",
+		Branch:                "my-branch",
+		TabletAlias:           "zone1-0000000100",
+		AppName:               "online-ddl",
+		Scope:                 "self",
+		SkipRequestHeartbeats: boolPtr(true),
+		OkIfNotExists:         boolPtr(true),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, `{"response_code":"THROTTLER_RESPONSE_CODE_OK"}`)
+}
+
+func TestVtctld_CheckThrottler_MinimalBody(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["tablet_alias"], qt.Equals, "zone1-0000000100")
+
+		// Optional fields are omitted entirely when unset.
+		_, hasAppName := body["app_name"]
+		c.Assert(hasAppName, qt.IsFalse)
+		_, hasSkip := body["skip_request_heartbeats"]
+		c.Assert(hasSkip, qt.IsFalse)
+
+		w.WriteHeader(200)
+		_, err = w.Write([]byte(`{"data":{"response_code":"THROTTLER_RESPONSE_CODE_OK"}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	_, err = client.Vtctld.CheckThrottler(ctx, &VtctldCheckThrottlerRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		TabletAlias:  "zone1-0000000100",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestVtctld_UpdateThrottlerConfig(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPut)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/throttler/config")
+
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["keyspace"], qt.Equals, "commerce")
+		c.Assert(body["enabled"], qt.Equals, true)
+		c.Assert(body["threshold"], qt.Equals, float64(2.5))
+
+		apps, ok := body["apps"].([]interface{})
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(len(apps), qt.Equals, 1)
+		app := apps[0].(map[string]interface{})
+		c.Assert(app["name"], qt.Equals, "online-ddl")
+		c.Assert(app["ratio"], qt.Equals, float64(0.5))
+
+		w.WriteHeader(200)
+		_, err = w.Write([]byte(`{"data":{}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	_, err = client.Vtctld.UpdateThrottlerConfig(ctx, &VtctldUpdateThrottlerConfigRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		Keyspace:     "commerce",
+		Enabled:      true,
+		Threshold:    float64Ptr(2.5),
+		Apps: []VtctldThrottledAppConfig{
+			{Name: "online-ddl", Ratio: float64Ptr(0.5)},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestVtctld_UpdateThrottlerConfig_DisableSendsEnabledFalse(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+
+		// enabled is a plain bool, so it is always present in the body, even
+		// when false. The server has no tri-state, so this must be explicit.
+		_, hasEnabled := body["enabled"]
+		c.Assert(hasEnabled, qt.IsTrue)
+		c.Assert(body["enabled"], qt.Equals, false)
+
+		// Optional threshold/apps are omitted when unset.
+		_, hasThreshold := body["threshold"]
+		c.Assert(hasThreshold, qt.IsFalse)
+
+		w.WriteHeader(200)
+		_, err = w.Write([]byte(`{"data":{}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	_, err = client.Vtctld.UpdateThrottlerConfig(ctx, &VtctldUpdateThrottlerConfigRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		Keyspace:     "commerce",
+		Enabled:      false,
+	})
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
Adds client methods for the three tablet throttler endpoints, so callers can inspect and configure the Vitess tablet throttler through the PlanetScale API.

## New methods on `VtctldService`

| Method | Endpoint | Scope |
|--------|----------|-------|
| `GetThrottlerStatus` | `GET …/vtctld/throttler/status` | tablet |
| `CheckThrottler` | `POST …/vtctld/throttler/check` | tablet |
| `UpdateThrottlerConfig` | `PUT …/vtctld/throttler/config` | keyspace |

`GetThrottlerStatus` and `CheckThrottler` are tablet-scoped: the caller identifies a tablet by alias (discoverable via `ListTablets`) and receives the raw JSON response, consistent with the existing `ListWorkflows`/`ListKeyspaces` methods. `UpdateThrottlerConfig` is keyspace-scoped.

## Notes on the request types

- `VtctldUpdateThrottlerConfigRequest.Enabled` is a plain `bool` rather than a pointer, because the endpoint requires it explicitly — omitting it would disable the throttler.
- `Threshold` and per-app `Ratio` are `*float64` so they can be omitted, letting the server apply its defaults.
- Optional check flags (`SkipRequestHeartbeats`, `OkIfNotExists`) are `*bool` and only sent when set.

## Testing

Added table-style tests covering each method: query/body serialization, omitted-optional behavior, and the explicit enable/disable path. `go test`, `go vet`, `gofmt`, and `golangci-lint` all pass.