### PR TITLE
[Fast lane] Support strategy in deploy requests cli

### DIFF
--- a/planetscale/deploy_requests.go
+++ b/planetscale/deploy_requests.go
@@ -51,6 +51,7 @@ type PerformDeployRequest struct {
 	Database     string `json:"-"`
 	Number       uint64 `json:"-"`
 	InstantDDL   bool   `json:"instant_ddl"`
+	Strategy     string `json:"strategy,omitempty"`
 }
 
 // GetDeployRequest encapsulates the request for getting a single deploy

--- a/planetscale/deploy_requests_test.go
+++ b/planetscale/deploy_requests_test.go
@@ -3,9 +3,11 @@ package planetscale
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +140,63 @@ func TestDeployRequests_InstantDeploy(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(dr, qt.DeepEquals, want)
+}
+
+func TestDeployRequests_DeployWithStrategy(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			InstantDDL bool   `json:"instant_ddl"`
+			Strategy   string `json:"strategy"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&request)
+		c.Assert(err, qt.IsNil)
+		c.Assert(request.Strategy, qt.Equals, "parallel")
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": "2021-01-14T10:19:23.000Z", "deployment": { "state": "queued" }, "number": 1337}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	_, err = client.DeployRequests.Deploy(ctx, &PerformDeployRequest{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+		Strategy:     "parallel",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestDeployRequests_DeployOmitsEmptyStrategy(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(string(raw), "strategy"), qt.IsFalse)
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": "2021-01-14T10:19:23.000Z", "deployment": { "state": "queued" }, "number": 1337}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	_, err = client.DeployRequests.Deploy(ctx, &PerformDeployRequest{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+	})
+	c.Assert(err, qt.IsNil)
 }
 
 func TestDeployRequests_CancelDeploy(t *testing.T) {


### PR DESCRIPTION
Adds a hidden strategy flag to the planetscale cli. It is gated behind a feature flag so it will do nothing if someone was to send it before we turn on the feature. Shipping this now, while hidden, will allow us to set up some scripted tests so we can do easily repeatable scenarios to ensure parallel deploys work properly.

`cc` https://github.com/planetscale/surfaces/issues/3692