### PR TITLE
Add Vtctld.GetRoutingRules client

### DIFF
--- a/planetscale/vtctld_general.go
+++ b/planetscale/vtctld_general.go
@@ -15,6 +15,7 @@ import (
 type VtctldService interface {
 	ListWorkflows(context.Context, *VtctldListWorkflowsRequest) (json.RawMessage, error)
 	ListKeyspaces(context.Context, *VtctldListKeyspacesRequest) (json.RawMessage, error)
+	GetRoutingRules(context.Context, *VtctldGetRoutingRulesRequest) (json.RawMessage, error)
 	ListTablets(context.Context, *ListBranchTabletsRequest) ([]*TabletGroup, error)
 	StartWorkflow(context.Context, *VtctldStartWorkflowRequest) (json.RawMessage, error)
 	StopWorkflow(context.Context, *VtctldStopWorkflowRequest) (json.RawMessage, error)
@@ -38,6 +39,14 @@ type VtctldListKeyspacesRequest struct {
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
 	Name         string `json:"-"`
+}
+
+// VtctldGetRoutingRulesRequest is a request for reading live routing rules
+// from the cluster via vtctld.
+type VtctldGetRoutingRulesRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
 }
 
 // VtctldStartWorkflowRequest is a request for starting a workflow.
@@ -138,6 +147,10 @@ func vtctldKeyspacesAPIPath(org, db, branch string) string {
 	return path.Join(databaseBranchAPIPath(org, db, branch), "vtctld", "keyspaces")
 }
 
+func vtctldRoutingRulesAPIPath(org, db, branch string) string {
+	return path.Join(databaseBranchAPIPath(org, db, branch), "vtctld", "routing-rules")
+}
+
 func (s *vtctldService) ListWorkflows(ctx context.Context, req *VtctldListWorkflowsRequest) (json.RawMessage, error) {
 	p := vtctldWorkflowsAPIPath(req.Organization, req.Database, req.Branch)
 	v := url.Values{}
@@ -166,6 +179,19 @@ func (s *vtctldService) ListKeyspaces(ctx context.Context, req *VtctldListKeyspa
 		v.Set("name", req.Name)
 	}
 	httpReq, err := s.client.newRequest(http.MethodGet, p, nil, WithQueryParams(v))
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+	resp := &vtctldDataResponse{}
+	if err := s.client.do(ctx, httpReq, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (s *vtctldService) GetRoutingRules(ctx context.Context, req *VtctldGetRoutingRulesRequest) (json.RawMessage, error) {
+	p := vtctldRoutingRulesAPIPath(req.Organization, req.Database, req.Branch)
+	httpReq, err := s.client.newRequest(http.MethodGet, p, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/vtctld_general_test.go
+++ b/planetscale/vtctld_general_test.go
@@ -128,7 +128,7 @@ func TestVtctld_GetRoutingRules(t *testing.T) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/routing-rules")
 
 		w.WriteHeader(200)
-		_, err := w.Write([]byte(`{"data":{"rules":{"rules":[]}}}`))
+		_, err := w.Write([]byte(`{"data":{"rules":[]}}`))
 		c.Assert(err, qt.IsNil)
 	}))
 	defer ts.Close()
@@ -143,7 +143,7 @@ func TestVtctld_GetRoutingRules(t *testing.T) {
 		Branch:       "my-branch",
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(data), qt.Equals, `{"rules":{"rules":[]}}`)
+	c.Assert(string(data), qt.Equals, `{"rules":[]}`)
 }
 
 func TestVtctld_ListKeyspaces(t *testing.T) {

--- a/planetscale/vtctld_general_test.go
+++ b/planetscale/vtctld_general_test.go
@@ -120,6 +120,32 @@ func TestVtctld_ListWorkflows_IncludeLogs(t *testing.T) {
 	}
 }
 
+func TestVtctld_GetRoutingRules(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/routing-rules")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"data":{"rules":{"rules":[]}}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	data, err := client.Vtctld.GetRoutingRules(ctx, &VtctldGetRoutingRulesRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, `{"rules":{"rules":[]}}`)
+}
+
 func TestVtctld_ListKeyspaces(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Adds a client method for reading live routing rules from a branch via vtctld:

- `GET …/vtctld/routing-rules`
- `Vtctld.GetRoutingRules(ctx, *VtctldGetRoutingRulesRequest) (json.RawMessage, error)`

This complements the existing schema-snapshot routing rules API with a live cluster read path.