### PR TITLE
Add Vtctld.GetShard client

### DIFF
--- a/planetscale/vtctld_general.go
+++ b/planetscale/vtctld_general.go
@@ -16,6 +16,7 @@ type VtctldService interface {
 	ListWorkflows(context.Context, *VtctldListWorkflowsRequest) (json.RawMessage, error)
 	ListKeyspaces(context.Context, *VtctldListKeyspacesRequest) (json.RawMessage, error)
 	GetRoutingRules(context.Context, *VtctldGetRoutingRulesRequest) (json.RawMessage, error)
+	GetShard(context.Context, *VtctldGetShardRequest) (json.RawMessage, error)
 	ListTablets(context.Context, *ListBranchTabletsRequest) ([]*TabletGroup, error)
 	StartWorkflow(context.Context, *VtctldStartWorkflowRequest) (json.RawMessage, error)
 	StopWorkflow(context.Context, *VtctldStopWorkflowRequest) (json.RawMessage, error)
@@ -47,6 +48,16 @@ type VtctldGetRoutingRulesRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
+}
+
+// VtctldGetShardRequest is a request for reading a shard record from the
+// cluster via vtctld.
+type VtctldGetShardRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+	Keyspace     string `json:"-"`
+	Shard        string `json:"-"`
 }
 
 // VtctldStartWorkflowRequest is a request for starting a workflow.
@@ -151,6 +162,10 @@ func vtctldRoutingRulesAPIPath(org, db, branch string) string {
 	return path.Join(databaseBranchAPIPath(org, db, branch), "vtctld", "routing-rules")
 }
 
+func vtctldShardAPIPath(org, db, branch string) string {
+	return path.Join(databaseBranchAPIPath(org, db, branch), "vtctld", "shard")
+}
+
 func (s *vtctldService) ListWorkflows(ctx context.Context, req *VtctldListWorkflowsRequest) (json.RawMessage, error) {
 	p := vtctldWorkflowsAPIPath(req.Organization, req.Database, req.Branch)
 	v := url.Values{}
@@ -192,6 +207,22 @@ func (s *vtctldService) ListKeyspaces(ctx context.Context, req *VtctldListKeyspa
 func (s *vtctldService) GetRoutingRules(ctx context.Context, req *VtctldGetRoutingRulesRequest) (json.RawMessage, error) {
 	p := vtctldRoutingRulesAPIPath(req.Organization, req.Database, req.Branch)
 	httpReq, err := s.client.newRequest(http.MethodGet, p, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+	resp := &vtctldDataResponse{}
+	if err := s.client.do(ctx, httpReq, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (s *vtctldService) GetShard(ctx context.Context, req *VtctldGetShardRequest) (json.RawMessage, error) {
+	p := vtctldShardAPIPath(req.Organization, req.Database, req.Branch)
+	v := url.Values{}
+	v.Set("keyspace", req.Keyspace)
+	v.Set("shard", req.Shard)
+	httpReq, err := s.client.newRequest(http.MethodGet, p, nil, WithQueryParams(v))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/vtctld_general_test.go
+++ b/planetscale/vtctld_general_test.go
@@ -146,6 +146,36 @@ func TestVtctld_GetRoutingRules(t *testing.T) {
 	c.Assert(string(data), qt.Equals, `{"rules":[]}`)
 }
 
+func TestVtctld_GetShard(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/vtctld/shard")
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "commerce")
+		c.Assert(r.URL.Query().Get("shard"), qt.Equals, "-")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"data":{"keyspace":"commerce","name":"-"}}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	data, err := client.Vtctld.GetShard(ctx, &VtctldGetShardRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		Keyspace:     "commerce",
+		Shard:        "-",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, `{"keyspace":"commerce","name":"-"}`)
+}
+
 func TestVtctld_ListKeyspaces(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Adds a client method for reading live shard records from a branch via vtctld:

- `GET …/vtctld/shard?keyspace=&shard=`
- `Vtctld.GetShard(ctx, *VtctldGetShardRequest) (json.RawMessage, error)`