### PR TITLE
Add keyspace, shard, and tablet-type/alias filters to ListTablets

### DIFF
--- a/planetscale/vtctld_tablets.go
+++ b/planetscale/vtctld_tablets.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
+	"strings"
 )
 
 // TabletGroup represents a group of tablets in a keyspace/shard.
@@ -27,6 +29,20 @@ type ListBranchTabletsRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
+
+	// The following are optional filters that mirror vtctldclient GetTablets.
+
+	// Keyspace, if set, only returns tablets in this keyspace.
+	Keyspace string `json:"-"`
+	// Shard, if set, only returns tablets in this shard. It requires Keyspace
+	// to also be set.
+	Shard string `json:"-"`
+	// TabletType, if set, only returns tablets of this type (e.g. "primary",
+	// "replica", "rdonly").
+	TabletType string `json:"-"`
+	// TabletAliases, if set, only returns the tablets with these aliases (e.g.
+	// "zone1-0000000100"). When set, the other filters are ignored.
+	TabletAliases []string `json:"-"`
 }
 
 func tabletsAPIPath(org, db, branch string) string {
@@ -35,7 +51,22 @@ func tabletsAPIPath(org, db, branch string) string {
 
 func (s *vtctldService) ListTablets(ctx context.Context, req *ListBranchTabletsRequest) ([]*TabletGroup, error) {
 	p := tabletsAPIPath(req.Organization, req.Database, req.Branch)
-	httpReq, err := s.client.newRequest(http.MethodGet, p, nil)
+
+	v := url.Values{}
+	if req.Keyspace != "" {
+		v.Set("keyspace", req.Keyspace)
+	}
+	if req.Shard != "" {
+		v.Set("shard", req.Shard)
+	}
+	if req.TabletType != "" {
+		v.Set("tablet_type", req.TabletType)
+	}
+	if len(req.TabletAliases) > 0 {
+		v.Set("tablet_alias", strings.Join(req.TabletAliases, ","))
+	}
+
+	httpReq, err := s.client.newRequest(http.MethodGet, p, nil, WithQueryParams(v))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/planetscale/vtctld_tablets_test.go
+++ b/planetscale/vtctld_tablets_test.go
@@ -1,0 +1,110 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestVtctld_ListTablets(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/tablets")
+
+		// No filters set, so none should be present on the request.
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "")
+		c.Assert(r.URL.Query().Get("shard"), qt.Equals, "")
+		c.Assert(r.URL.Query().Get("tablet_type"), qt.Equals, "")
+		c.Assert(r.URL.Query().Get("tablet_alias"), qt.Equals, "")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`[{"type":"primary","keyspace":"commerce","shard":"-","tablets":[{"alias":"zone1-100","role":"primary","cell":"zone1"}]}]`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	groups, err := client.Vtctld.ListTablets(ctx, &ListBranchTabletsRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(groups, qt.DeepEquals, []*TabletGroup{
+		{
+			Type:     "primary",
+			Keyspace: "commerce",
+			Shard:    "-",
+			Tablets: []Tablet{
+				{Alias: "zone1-100", Role: "primary", Cell: "zone1"},
+			},
+		},
+	})
+}
+
+func TestVtctld_ListTablets_Filters(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/tablets")
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "commerce")
+		c.Assert(r.URL.Query().Get("shard"), qt.Equals, "-80")
+		c.Assert(r.URL.Query().Get("tablet_type"), qt.Equals, "replica")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`[]`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	_, err = client.Vtctld.ListTablets(ctx, &ListBranchTabletsRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+		Keyspace:     "commerce",
+		Shard:        "-80",
+		TabletType:   "replica",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestVtctld_ListTablets_TabletAliases(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/tablets")
+		// Multiple aliases are sent as a single comma-separated value.
+		c.Assert(r.URL.Query().Get("tablet_alias"), qt.Equals, "zone1-0000000100,zone1-0000000101")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`[]`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	_, err = client.Vtctld.ListTablets(ctx, &ListBranchTabletsRequest{
+		Organization:  "my-org",
+		Database:      "my-db",
+		Branch:        "my-branch",
+		TabletAliases: []string{"zone1-0000000100", "zone1-0000000101"},
+	})
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary

`Vtctld.ListTablets` sent no query parameters, so callers (notably `pscale branch list-tablets`) had to fetch every tablet on a branch and filter client-side. On large, multi-keyspace branches that makes finding a specific tablet alias painful

## Changes

`ListBranchTabletsRequest` gains four optional filter fields:

- `Keyspace`, `Shard`, `TabletType` — sent as `keyspace` / `shard` / `tablet_type` query parameters.
- `TabletAliases []string` — sent as a single comma-separated `tablet_alias` query parameter (matching the api-bb contract). When set, the server ignores the other filters.

Only non-empty filters are added to the query string, so an unfiltered `ListTablets` call behaves exactly as before. The implementation uses the same `WithQueryParams` pattern as the other `Vtctld` methods (`ListWorkflows`, `ListKeyspaces`).

## Testing

Added `vtctld_tablets_test.go` (there was no test file before):

- unfiltered request sends no filter params and decodes the grouped response;
- keyspace + shard + tablet_type are sent as the expected query params;
- multiple `TabletAliases` are serialized into one comma-separated `tablet_alias` value.

`go build`, `go vet`, `gofmt`, and the full `./planetscale/` test suite pass locally.