### PR TITLE
Add PostgresBranches.Resize client

### DIFF
--- a/planetscale/postgres_branches.go
+++ b/planetscale/postgres_branches.go
@@ -262,6 +262,13 @@ func (p *postgresBranchesService) Resize(ctx context.Context, resizeReq *ResizeP
 		return nil, err
 	}
 
+	// A 204 No Content response (requested configuration already matches the
+	// current one) leaves the body, and therefore the ID, empty. Surface that
+	// as a nil change request so callers can detect the no-op.
+	if change.ID == "" {
+		return nil, nil
+	}
+
 	return change, nil
 }
 

--- a/planetscale/postgres_branches.go
+++ b/planetscale/postgres_branches.go
@@ -67,6 +67,40 @@ type DeletePostgresBranchRequest struct {
 	DeleteDescendants bool
 }
 
+// ResizePostgresBranchRequest encapsulates the request to resize a Postgres
+// branch's cluster (and optionally change its replica count).
+type ResizePostgresBranchRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+
+	// ClusterSize is the fully-qualified cluster size SKU name to resize to,
+	// e.g. "PS_10_GCP_X86". Use the values returned by ListClusterSKUs.
+	ClusterSize string `json:"cluster_size,omitempty"`
+	// Replicas is the desired number of replicas. Nil leaves it unchanged.
+	Replicas *int `json:"replicas,omitempty"`
+}
+
+// PostgresBranchClusterResizeRequest represents an asynchronous Postgres branch
+// cluster change (resize) request.
+type PostgresBranchClusterResizeRequest struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+
+	ClusterName        string `json:"cluster_name"`
+	ClusterDisplayName string `json:"cluster_display_name"`
+	Replicas           int    `json:"replicas"`
+
+	PreviousClusterName        string `json:"previous_cluster_name"`
+	PreviousClusterDisplayName string `json:"previous_cluster_display_name"`
+	PreviousReplicas           int    `json:"previous_replicas"`
+
+	StartedAt   *time.Time `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
 // PostgresBranchSchemaRequest encapsulates the request to get the schema of a Postgres branch.
 type PostgresBranchSchemaRequest struct {
 	Organization string
@@ -94,6 +128,7 @@ type PostgresBranchesService interface {
 	Delete(context.Context, *DeletePostgresBranchRequest) error
 	Schema(context.Context, *PostgresBranchSchemaRequest) ([]*PostgresBranchSchema, error)
 	ListClusterSKUs(context.Context, *ListBranchClusterSKUsRequest, ...ListOption) ([]*ClusterSKU, error)
+	Resize(context.Context, *ResizePostgresBranchRequest) (*PostgresBranchClusterResizeRequest, error)
 }
 
 type postgresBranchesService struct {
@@ -208,6 +243,26 @@ func (p *postgresBranchesService) ListClusterSKUs(ctx context.Context, listReq *
 	}
 
 	return clusterSKUs, nil
+}
+
+// Resize starts an asynchronous resize of a Postgres branch's cluster (and
+// optionally changes its replica count). It returns the resulting change
+// request, whose State can be polled via the branch changes API. A nil change
+// request is returned when the requested configuration matches the current one
+// (the API responds 204 No Content).
+func (p *postgresBranchesService) Resize(ctx context.Context, resizeReq *ResizePostgresBranchRequest) (*PostgresBranchClusterResizeRequest, error) {
+	path := path.Join(postgresBranchAPIPath(resizeReq.Organization, resizeReq.Database, resizeReq.Branch), "changes")
+	req, err := p.client.newRequest(http.MethodPatch, path, resizeReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	change := &PostgresBranchClusterResizeRequest{}
+	if err := p.client.do(ctx, req, change); err != nil {
+		return nil, err
+	}
+
+	return change, nil
 }
 
 // Schema returns the schema for the specified Postgres branch.

--- a/planetscale/postgres_branches_test.go
+++ b/planetscale/postgres_branches_test.go
@@ -366,6 +366,32 @@ func TestPostgresBranches_Resize(t *testing.T) {
 	c.Assert(change.PreviousClusterName, qt.Equals, "PS_5_GCP_X86")
 }
 
+func TestPostgresBranches_ResizeNoOp(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/postgres-test-db/branches/postgres-test-branch/changes")
+		// The requested configuration already matches: 204 No Content.
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	change, err := client.PostgresBranches.Resize(ctx, &ResizePostgresBranchRequest{
+		Organization: "my-org",
+		Database:     "postgres-test-db",
+		Branch:       testPostgresBranch,
+		ClusterSize:  "PS_5_GCP_X86",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(change, qt.IsNil)
+}
+
 func TestPostgresBranches_CreateWithStorage(t *testing.T) {
 	c := qt.New(t)
 

--- a/planetscale/postgres_branches_test.go
+++ b/planetscale/postgres_branches_test.go
@@ -326,6 +326,46 @@ func TestPostgresBranches_ListClusterSKUs(t *testing.T) {
 	c.Assert(skus, qt.DeepEquals, want)
 }
 
+func TestPostgresBranches_Resize(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/postgres-test-db/branches/postgres-test-branch/changes")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["cluster_size"], qt.Equals, "PS_10_GCP_X86")
+		// Replicas is unset, so it must be omitted from the request body.
+		_, hasReplicas := body["replicas"]
+		c.Assert(hasReplicas, qt.IsFalse)
+
+		w.WriteHeader(200)
+		out := `{"id":"resize-1","state":"queued","cluster_name":"PS_10_GCP_X86","cluster_display_name":"PS-10","replicas":0,"previous_cluster_name":"PS_5_GCP_X86","previous_cluster_display_name":"PS-5","previous_replicas":0,"created_at":"2026-06-24T10:19:23.000Z","updated_at":"2026-06-24T10:19:23.000Z"}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	change, err := client.PostgresBranches.Resize(ctx, &ResizePostgresBranchRequest{
+		Organization: "my-org",
+		Database:     "postgres-test-db",
+		Branch:       testPostgresBranch,
+		ClusterSize:  "PS_10_GCP_X86",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(change.ID, qt.Equals, "resize-1")
+	c.Assert(change.State, qt.Equals, "queued")
+	c.Assert(change.ClusterName, qt.Equals, "PS_10_GCP_X86")
+	c.Assert(change.PreviousClusterName, qt.Equals, "PS_5_GCP_X86")
+}
+
 func TestPostgresBranches_CreateWithStorage(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What

Adds `PostgresBranches.Resize`, a client for resizing a Postgres branch's cluster (and optionally changing its replica count).

```
PATCH /organizations/{org}/databases/{db}/branches/{branch}/changes
body:  { "cluster_size": "PS_10_GCP_X86", "replicas": <optional> }
→ 200 PostgresClusterResizeRequest  (async; poll .State)
→ 204 when the requested config already matches
```

## Correction from the first revision

The first version of this PR targeted `PATCH .../branches/{branch}/cluster` (`update_branch_cluster_config`). That endpoint is **MySQL/Vitess-only**: it builds a `keyspace_resize_request`, whose `enforce_mysql` validation rejects any non-MySQL database with `422 "Resize is not supported"`. Verified against a live Postgres branch — it cannot resize Postgres.

The correct Postgres path is the **branch change request** endpoint (`PATCH .../changes`), which is asynchronous and returns a `PostgresClusterResizeRequest`.

## API surface

```go
type ResizePostgresBranchRequest struct {
    Organization string `json:"-"`
    Database     string `json:"-"`
    Branch       string `json:"-"`
    ClusterSize  string `json:"cluster_size,omitempty"`
    Replicas     *int   `json:"replicas,omitempty"`
}

Resize(context.Context, *ResizePostgresBranchRequest) (*PostgresBranchClusterResizeRequest, error)
```

`PostgresBranchClusterResizeRequest` carries `ID`, `State`, `ClusterName`/`ClusterDisplayName`, `Replicas`, the `Previous*` equivalents, and timestamps.

## Notes

- `cluster_size` must be the **fully-qualified SKU name** (e.g. `PS_10_GCP_X86`) as returned by `ListClusterSKUs` — the short tshirt form (`PS_10`) returns `422` from this endpoint.
- Verified end-to-end against a live Postgres branch: PS-5 → PS-10 resize returned a `resizing` change request and completed; the second concurrent call correctly returned "cluster resize in progress".

## Testing

- `TestPostgresBranches_Resize` asserts the PATCH verb, `.../changes` path, `cluster_size` body (with `replicas` omitted when unset), and parsing of the returned change request.
- `go test ./...` passes.