### PR TITLE
Add GlobalKeyspace to MoveTablesCreateRequest

### DIFF
--- a/planetscale/vtctld_move_tables.go
+++ b/planetscale/vtctld_move_tables.go
@@ -37,6 +37,7 @@ type MoveTablesCreateRequest struct {
 	DeferSecondaryKeys           *bool    `json:"defer_secondary_keys,omitempty"`
 	OnDDL                        string   `json:"on_ddl,omitempty"`
 	ShardedAutoIncrementHandling string   `json:"sharded_auto_increment_handling,omitempty"`
+	GlobalKeyspace               string   `json:"global_keyspace,omitempty"`
 	SourceTimeZone               string   `json:"source_time_zone,omitempty"`
 	TenantID                     string   `json:"tenant_id,omitempty"`
 	Cells                        []string `json:"cells,omitempty"`

--- a/planetscale/vtctld_move_tables_test.go
+++ b/planetscale/vtctld_move_tables_test.go
@@ -33,6 +33,7 @@ func TestMoveTables_Create(t *testing.T) {
 		_, hasTabletTypes := body["tablet_types"]
 		_, hasExcludeTables := body["exclude_tables"]
 		_, hasTenantID := body["tenant_id"]
+		_, hasGlobalKeyspace := body["global_keyspace"]
 		c.Assert(hasAllTables, qt.IsFalse)
 		c.Assert(hasAutoStart, qt.IsFalse)
 		c.Assert(hasStopAfterCopy, qt.IsFalse)
@@ -42,6 +43,7 @@ func TestMoveTables_Create(t *testing.T) {
 		c.Assert(hasTabletTypes, qt.IsFalse)
 		c.Assert(hasExcludeTables, qt.IsFalse)
 		c.Assert(hasTenantID, qt.IsFalse)
+		c.Assert(hasGlobalKeyspace, qt.IsFalse)
 
 		w.WriteHeader(http.StatusAccepted)
 		_, err = w.Write([]byte(`{"id":"create-op"}`))
@@ -95,6 +97,43 @@ func TestMoveTables_CreateWithTenantID(t *testing.T) {
 		TargetKeyspace: "target",
 		SourceKeyspace: "source",
 		TenantID:       "tenant-123",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(ref, qt.DeepEquals, &VtctldOperationReference{ID: "create-op"})
+}
+
+func TestMoveTables_CreateWithGlobalKeyspace(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/move-tables/workflows")
+
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["global_keyspace"], qt.Equals, "global")
+		c.Assert(body["sharded_auto_increment_handling"], qt.Equals, "REPLACE")
+
+		w.WriteHeader(http.StatusAccepted)
+		_, err = w.Write([]byte(`{"id":"create-op"}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	ref, err := client.MoveTables.Create(ctx, &MoveTablesCreateRequest{
+		Organization:                 "my-org",
+		Database:                     "my-db",
+		Branch:                       "my-branch",
+		Workflow:                     "my-workflow",
+		TargetKeyspace:               "target",
+		SourceKeyspace:               "source",
+		ShardedAutoIncrementHandling: "REPLACE",
+		GlobalKeyspace:               "global",
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(ref, qt.DeepEquals, &VtctldOperationReference{ID: "create-op"})


### PR DESCRIPTION
## Summary

Adds a `GlobalKeyspace` field to `MoveTablesCreateRequest`, exposing the vtctld `MoveTables create --global-keyspace` option on the direct vtctld path.

Without it, `--sharded-auto-increment-handling=REPLACE` cannot auto-create the backing sequence tables at `switch-traffic --initialize-target-sequences` time — customers have to manually declare each `<table>_seq` sequence in an unsharded keyspace's vschema before cutover.

The server side already supports the parameter; the `pscale` CLI change is a separate follow-up. The managed-workflow surface (`WorkflowsService`, `workflows.go`) already has this field — this uses the same `global_keyspace` JSON key.

## Changes

- `MoveTablesCreateRequest.GlobalKeyspace` (`json:"global_keyspace,omitempty"`), placed next to `ShardedAutoIncrementHandling` since the two options work together
- Test coverage: omitted-when-unset assertions in `TestMoveTables_Create`, and a new `TestMoveTables_CreateWithGlobalKeyspace` exercising the field alongside `sharded_auto_increment_handling=REPLACE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)