### PR TITLE
Update README: client development moved to the cli repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Go package to access the PlanetScale API.
 
+> [!NOTE]
+> This repository is a read-only mirror. The client is developed in the
+> [pscale CLI repository](https://github.com/planetscale/cli) at
+> `internal/planetscale/` and synced here automatically, so external users of
+> this module keep getting updates through the usual tagged releases.
+>
+> The module remains fully supported: keep importing
+> `github.com/planetscale/planetscale-go/planetscale` as before. However,
+> please do not open pull requests that change the client code here, since the
+> next sync would overwrite them. Code contributions belong in the
+> [cli repository](https://github.com/planetscale/cli). Bug reports and
+> feature requests are welcome as issues on either repo.
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Go package to access the PlanetScale API.
 > `github.com/planetscale/planetscale-go/planetscale` as before. However,
 > please do not open pull requests that change the client code here, since the
 > next sync would overwrite them. Code contributions belong in the
-> [cli repository](https://github.com/planetscale/cli). Bug reports and
-> feature requests are welcome as issues on either repo.
+> [cli repository](https://github.com/planetscale/cli).
 
 ## Install
 


### PR DESCRIPTION
## Summary

The Go client is now developed in the [cli repository](https://github.com/planetscale/cli) at `internal/planetscale/` and synced into this repo automatically. 

The note makes three things clear:
- This repo is a read-only mirror, updated by an automated sync that opens PRs here.
- The module keeps working exactly as before for external users, same import path, same tagged releases.
- Client code changes belong in the cli repo, since changes made here would be overwritten by the next sync.